### PR TITLE
feat: sync MZC-CSC/develop → m-cmp/main (65 commits)

### DIFF
--- a/.github/workflows/no-ai-trace.yml
+++ b/.github/workflows/no-ai-trace.yml
@@ -1,0 +1,145 @@
+# ------------------------------------------------------------
+# Policy enforcement for open-source contributions: block AI direct commit signoff and co-authored-by attribution from being merged.
+#
+# In open-source contributions, the human author is expected to create commits and open pull requests. Under current open-source license frameworks (DCO, Sign-off, CLA, etc.) AI-attributed commits may have unclear implications. Following the community proposal from 2026-05-08, until the project policy is finalized, AI direct commit signoff and co-authored-by records are prohibited.
+#
+# Canonical source: https://github.com/MZC-CSC/cmig-workflow/blob/main/conf/workflow-templates/no-ai-trace.yml
+# Reference policy: https://github.com/MZC-CSC/cmig-workflow/blob/main/POLICY-AI-TRACE-GUARD.md
+# Local path in target repo: .github/workflows/no-ai-trace.yml
+# ------------------------------------------------------------
+
+name: AI Direct Commit Attribution Check
+
+on:
+  pull_request:
+    branches: [main, develop, master]
+  push:
+    branches: [main, develop, master]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  block-ai-attribution:
+    name: Block AI direct commit signoff and co-authored-by
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine commit range to scan
+        id: range
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "from=${{ github.event.pull_request.base.sha }}" >> $GITHUB_OUTPUT
+            echo "to=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          else
+            BEFORE="${{ github.event.before }}"
+            if [ "$BEFORE" = "0000000000000000000000000000000000000000" ] || [ -z "$BEFORE" ]; then
+              echo "from=${{ github.sha }}~1" >> $GITHUB_OUTPUT
+            else
+              echo "from=$BEFORE" >> $GITHUB_OUTPUT
+            fi
+            echo "to=${{ github.sha }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Scan commits for AI direct attribution
+        id: scan
+        run: |
+          FROM="${{ steps.range.outputs.from }}"
+          TO="${{ steps.range.outputs.to }}"
+
+          # Patterns matched against commit message body and trailers
+          BODY_PATTERNS='Co-Authored-By:.*[Cc]laude|Co-Authored-By:.*[Aa]nthropic|Co-Authored-By:.*[Cc]opilot|Generated-By:.*[Cc]laude|Generated-By:.*[Cc]ode|Assisted-By|Co-Developed-By|noreply@anthropic\.com'
+
+          # Patterns matched against author and committer email
+          EMAIL_PATTERNS='@anthropic\.com|copilot-swe-agent'
+
+          FOUND=""
+          for sha in $(git rev-list "$FROM..$TO" 2>/dev/null); do
+            SUBJECT=$(git log -1 --pretty='%s' "$sha")
+            BODY=$(git log -1 --pretty='%B' "$sha")
+            AUTHOR_EMAIL=$(git log -1 --pretty='%ae' "$sha")
+            COMMITTER_EMAIL=$(git log -1 --pretty='%ce' "$sha")
+
+            BAD=""
+            HIT=$(echo "$BODY" | grep -iE "$BODY_PATTERNS" | head -3)
+            if [ -n "$HIT" ]; then
+              BAD="$BAD"$'\n'"  - body/trailer match:"$'\n'"$(echo "$HIT" | sed 's/^/      /')"
+            fi
+
+            for email in "$AUTHOR_EMAIL" "$COMMITTER_EMAIL"; do
+              if echo "$email" | grep -iqE "$EMAIL_PATTERNS"; then
+                BAD="$BAD"$'\n'"  - AI tool email match: $email"
+              fi
+            done
+
+            if [ -n "$BAD" ]; then
+              FOUND="$FOUND"$'\n\n'"### $sha"$'\n'"  subject: $SUBJECT$BAD"
+            fi
+          done
+
+          if [ -n "$FOUND" ]; then
+            {
+              echo "found=true"
+              echo "details<<EOF"
+              echo "$FOUND"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
+
+            echo "::error::AI direct commit signoff or co-authored-by attribution detected. See logs and PR comment for details."
+            echo "$FOUND"
+            exit 1
+          fi
+
+          echo "found=false" >> $GITHUB_OUTPUT
+          echo "OK: no AI direct commit signoff or co-authored-by attribution found."
+
+      - name: Post failure comment on PR
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const details = `${{ steps.scan.outputs.details }}`;
+            const body = [
+              '## AI Direct Commit Attribution Blocked',
+              '',
+              'This pull request cannot be merged because it contains commits with AI tool attribution (Claude, Anthropic, GitHub Copilot, etc.) in commit message trailers (for example `Co-Authored-By`, `Signed-off-by`, `Generated-By`) or in the author/committer email.',
+              '',
+              '### Why this is blocked',
+              '',
+              'In open-source contributions, the human author is expected to create commits and open pull requests. Under current open-source license frameworks (DCO, Sign-off, CLA, etc.) AI-attributed commits may have unclear implications. Following the community proposal from 2026-05-08, until the project policy is finalized, **AI direct commit signoff and co-authored-by records are prohibited** in this repository.',
+              '',
+              '<details><summary>Matched commits</summary>',
+              '',
+              '```',
+              details,
+              '```',
+              '',
+              '</details>',
+              '',
+              '### How to fix',
+              '',
+              'Most recent commit only - strip the attribution trailers:',
+              '```bash',
+              'git commit --amend --message="$(git log -1 --pretty=\'%s%n%n%b\' | grep -vE \'Co-Authored-By:|Generated-By:|Assisted-By:|Co-Developed-By:\')"',
+              'git push --force-with-lease',
+              '```',
+              '',
+              'Multiple commits - use interactive rebase:',
+              '```bash',
+              'git rebase -i HEAD~5',
+              '# Mark each commit as `reword` and remove the trailer lines in the editor',
+              'git push --force-with-lease',
+              '```',
+              '',
+              'The check will re-run automatically after the force-push, and the merge can proceed once the AI direct commit signoff and co-authored-by records are removed. Repository administrators may also enforce this check via Branch Protection rules.'
+            ].join('\n');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });

--- a/api/internal/handler/apihosts.go
+++ b/api/internal/handler/apihosts.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -75,6 +76,7 @@ func GetApiHosts(c echo.Context) error {
 
 // refreshRegistryCache mc-iam-manager의 ListMcmpApisServices를 직접 호출하여 RegistryCache 갱신.
 // buildAuthHeader는 proxy.go에서 공유 (같은 handler 패키지).
+// 401 응답 시 RefreshToken 쿠키로 액세스 토큰을 자동 갱신 후 재시도한다.
 func refreshRegistryCache(cfg *config.Config, c echo.Context) error {
 	service, actionSpec, err := cfg.ApiSpec.GetAction("mc-iam-manager", "ListMcmpApisServices")
 	if err != nil {
@@ -82,27 +84,13 @@ func refreshRegistryCache(cfg *config.Config, c echo.Context) error {
 	}
 
 	targetURL := service.BaseURL + actionSpec.ResourcePath
-	req, err := http.NewRequest(strings.ToUpper(actionSpec.Method), targetURL, nil)
+	authHeader := buildAuthHeader(c, service)
+
+	body, err := doListMcmpApisServices(cfg, c, targetURL, actionSpec.Method, authHeader)
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Content-Type", "application/json")
 
-	if authHeader := buildAuthHeader(c, service); authHeader != "" {
-		req.Header.Set("Authorization", authHeader)
-	}
-
-	resp, err := (&http.Client{}).Do(req)
-	if err != nil {
-		return fmt.Errorf("ListMcmpApisServices call failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("ListMcmpApisServices returned %d", resp.StatusCode)
-	}
-
-	body, _ := io.ReadAll(resp.Body)
 	var responseData interface{}
 	if err := json.Unmarshal(body, &responseData); err != nil {
 		return fmt.Errorf("ListMcmpApisServices response parse failed: %w", err)
@@ -110,4 +98,93 @@ func refreshRegistryCache(cfg *config.Config, c echo.Context) error {
 
 	cfg.RegistryCache.Store(responseData)
 	return nil
+}
+
+// doListMcmpApisServices ListMcmpApisServices HTTP 호출.
+// 401 수신 시 RefreshToken 쿠키로 액세스 토큰 갱신 후 1회 재시도한다.
+func doListMcmpApisServices(cfg *config.Config, c echo.Context, targetURL, method, authHeader string) ([]byte, error) {
+	resp, err := callHTTP(strings.ToUpper(method), targetURL, authHeader)
+	if err != nil {
+		return nil, fmt.Errorf("ListMcmpApisServices call failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		newToken, refreshErr := refreshUserAccessToken(cfg, c)
+		if refreshErr != nil {
+			return nil, fmt.Errorf("ListMcmpApisServices 401, token refresh failed: %w", refreshErr)
+		}
+		log.Printf("[RegistryCache] token refreshed, retrying ListMcmpApisServices")
+		resp2, err2 := callHTTP(strings.ToUpper(method), targetURL, "Bearer "+newToken)
+		if err2 != nil {
+			return nil, fmt.Errorf("ListMcmpApisServices retry failed: %w", err2)
+		}
+		defer resp2.Body.Close()
+		if resp2.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("ListMcmpApisServices retry returned %d", resp2.StatusCode)
+		}
+		return io.ReadAll(resp2.Body)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ListMcmpApisServices returned %d", resp.StatusCode)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// callHTTP method/url/authHeader로 단순 HTTP 요청을 실행한다.
+func callHTTP(method, url, authHeader string) (*http.Response, error) {
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	return (&http.Client{}).Do(req)
+}
+
+// refreshUserAccessToken RefreshToken 쿠키를 이용해 mc-iam-manager에서 새 access_token 발급.
+func refreshUserAccessToken(cfg *config.Config, c echo.Context) (string, error) {
+	refreshCookie, err := c.Cookie("RefreshToken")
+	if err != nil || refreshCookie.Value == "" {
+		return "", fmt.Errorf("RefreshToken cookie not found")
+	}
+
+	service, actionSpec, err := cfg.ApiSpec.GetAction("mc-iam-manager", "loginrefresh")
+	if err != nil {
+		return "", fmt.Errorf("loginrefresh not found in api.yaml: %w", err)
+	}
+
+	targetURL := service.BaseURL + actionSpec.ResourcePath
+
+	body, _ := json.Marshal(map[string]string{"refresh_token": refreshCookie.Value})
+	req, err := http.NewRequest(http.MethodPost, targetURL, bytes.NewBuffer(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return "", fmt.Errorf("loginrefresh call failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("loginrefresh returned %d", resp.StatusCode)
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	var data map[string]interface{}
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return "", fmt.Errorf("loginrefresh response parse failed: %w", err)
+	}
+
+	accessToken, ok := data["access_token"].(string)
+	if !ok || accessToken == "" {
+		return "", fmt.Errorf("access_token not found in loginrefresh response")
+	}
+	return accessToken, nil
 }

--- a/front/assets/js/common/api/services/mci_api.js
+++ b/front/assets/js/common/api/services/mci_api.js
@@ -113,7 +113,7 @@ export async function getMciVm(nsId, mciId, vmId) {
     pathParams: {
       nsId: nsId,
       infraId: mciId,
-      vmId: vmId
+      nodeId: vmId
     }
   }
 

--- a/front/assets/js/pages/settings/environment/cloudsps/connections.js
+++ b/front/assets/js/pages/settings/environment/cloudsps/connections.js
@@ -20,8 +20,10 @@ const PROVIDER_BADGE = {
     azure:    '<span class="badge bg-indigo-lt">Azure</span>',
     alibaba:  '<span class="badge bg-yellow-lt">Alibaba</span>',
     ncp:      '<span class="badge bg-green-lt">NCP</span>',
-    nhncloud: '<span class="badge bg-cyan-lt">NHN</span>',
-    ktcloud:  '<span class="badge bg-teal-lt">KT</span>',
+    ibm:      '<span class="badge bg-purple-lt">IBM</span>',
+    nhn:      '<span class="badge bg-cyan-lt">NHN</span>',
+    kt:       '<span class="badge bg-teal-lt">KT</span>',
+    openstack: '<span class="badge bg-red-lt">OpenStack</span>',
     tencent:  '<span class="badge bg-red-lt">Tencent</span>',
 };
 

--- a/front/assets/js/pages/settings/environment/cloudsps/credentials.js
+++ b/front/assets/js/pages/settings/environment/cloudsps/credentials.js
@@ -20,9 +20,12 @@ const PROVIDER_KEYS = {
     gcp:       ['ClientEmail', 'PrivateKey', 'ProjectID'],
     azure:     ['ClientId', 'ClientSecret', 'TenantId', 'SubscriptionId'],
     alibaba:   ['ClientId', 'ClientSecret'],
+    ibm:       ['ApiKey', 'S3AccessKey', 'S3SecretKey'],
     ncp:       ['ClientId', 'ClientSecret'],
-    nhncloud:  ['ClientId', 'ClientSecret', 'TenantId'],
-    ktcloud:   ['ClientId', 'ClientSecret'],
+    nhn:       ['IdentityEndpoint', 'Username', 'Password', 'DomainName', 'TenantId'],
+    kt:        ['IdentityEndpoint', 'Username', 'Password', 'DomainName', 'ProjectID'],
+    openstack: ['IdentityEndpoint', 'Username', 'Password', 'DomainName', 'ProjectID'],
+    tencent:   ['SecretId', 'SecretKey'],
 };
 
 const PROVIDER_BADGE = {

--- a/front/templates/pages/settings/environment/cloudsps/credentials.html
+++ b/front/templates/pages/settings/environment/cloudsps/credentials.html
@@ -118,9 +118,12 @@
               <option value="gcp">GCP</option>
               <option value="azure">Azure</option>
               <option value="alibaba">Alibaba</option>
+              <option value="ibm">IBM</option>
               <option value="ncp">NCP</option>
-              <option value="nhncloud">NHN Cloud</option>
-              <option value="ktcloud">KT Cloud</option>
+              <option value="nhn">NHN Cloud</option>
+              <option value="kt">KT Cloud</option>
+              <option value="openstack">OpenStack</option>
+              <option value="tencent">Tencent</option>
             </select>
             <div class="invalid-feedback"></div>
           </div>


### PR DESCRIPTION
## Summary

- Credential/Connection 화면 개발
- CSP 전체 프로바이더 Credential 지원 추가
- MCI vm→node 필드명 및 pathParam 업데이트
- 사용자 승인 화면 추가
- 역할/메뉴 권한 사이드바 즉시 갱신 수정
- 조직 관련 메뉴 및 companyinfo 화면 버그 수정
- UI 텍스트 영문화 일괄 처리
- AI 직접 커밋 방지 CI 워크플로우 추가
- mc-infra-manager  API pathParam 수정
