### PR TITLE
feat:  MCI workload 버그 수정

### DIFF
--- a/doc/test/001_Workspaces_test.md
+++ b/doc/test/001_Workspaces_test.md
@@ -53,7 +53,7 @@
 | 42 | 사용자 관리 | 역할 선택 | 사용자에게 할당할 역할을 선택할 수 있는가 |  |  |
 | 43 | 사용자 관리 | 사용자 할당 | 선택한 사용자가 Workspace에 할당되는가 |  |  |
 | 44 | 사용자 관리 | 사용자 제거 | Users 탭에서 사용자 제거가 동작하는가 |  |  |
-| 45 | 사용자 관리 | API 호출 | createWorkspaceUserRoleMappingByName, deleteWorkspaceUserRoleMapping API가 호출되는가 |  |  |
+| 45 | 사용자 관리 | API 호출 | assignWorkspaceRole (POST /api/roles/assign/workspace-role), removeWorkspaceRole (DELETE /api/roles/unassign/workspace-role) API가 호출되는가 |  |  |
 | 46 | 테이블 기능 | 정렬 | 컬럼 클릭 시 정렬이 동작하는가 |  |  |
 | 47 | 테이블 기능 | 페이징 | 페이지 네비게이션이 정상 동작하는가 |  |  |
 | 48 | 테이블 기능 | 행 선택 | 체크박스를 통한 다중 선택이 동작하는가 |  |  |

--- a/front/actions/app.go
+++ b/front/actions/app.go
@@ -74,6 +74,8 @@ func App() *echo.Echo {
 
 		// API proxy (wildcard routing)
 		api := app.Group("/api")
+		// Specific handlers must be registered before the wildcard
+		api.POST("/mc-infra-manager/PostFileToInfra", PostFileToInfraHandler)
 		api.Any("/*", ApiCaller)
 
 		// Static file serving - serve webpack build output from public directory

--- a/front/actions/app.go
+++ b/front/actions/app.go
@@ -76,6 +76,7 @@ func App() *echo.Echo {
 		api := app.Group("/api")
 		// Specific handlers must be registered before the wildcard
 		api.POST("/mc-infra-manager/PostFileToInfra", PostFileToInfraHandler)
+		api.POST("/mc-infra-manager/PostCmdInfra", PostCmdInfraHandler)
 		api.Any("/*", ApiCaller)
 
 		// Static file serving - serve webpack build output from public directory

--- a/front/actions/cmd.go
+++ b/front/actions/cmd.go
@@ -1,0 +1,98 @@
+package actions
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+)
+
+type cmdPathParams struct {
+	NsId    string `json:"nsId"`
+	InfraId string `json:"infraId"`
+}
+
+type cmdRequest struct {
+	Command  interface{} `json:"command"`
+	UserName string      `json:"userName"`
+}
+
+type cmdCommonRequest struct {
+	PathParams  cmdPathParams          `json:"pathParams"`
+	QueryParams map[string]interface{} `json:"queryParams"`
+	Request     cmdRequest             `json:"Request"`
+}
+
+// PostCmdInfraHandler forwards a remote command request to mc-infra-manager.
+// The JS sends JSON with pathParams/Request; this handler calls mc-infra-manager
+// directly with Basic auth, bypassing the API proxy which lacks this action.
+func PostCmdInfraHandler(c echo.Context) error {
+	var req cmdCommonRequest
+	if err := json.NewDecoder(c.Request().Body).Decode(&req); err != nil {
+		return respondCmdError(c, http.StatusBadRequest, "invalid request body: "+err.Error())
+	}
+
+	nsId := req.PathParams.NsId
+	mciId := req.PathParams.InfraId
+	if nsId == "" || mciId == "" {
+		return respondCmdError(c, http.StatusBadRequest, "nsId and infraId are required")
+	}
+
+	// Build mc-infra-manager URL
+	targetURL := fmt.Sprintf("%s/ns/%s/cmd/infra/%s", INFRA_MANAGER_URL, nsId, mciId)
+
+	// Forward optional queryParams (subGroupId, vmId, etc.)
+	if len(req.QueryParams) > 0 {
+		params := []string{}
+		for k, v := range req.QueryParams {
+			params = append(params, fmt.Sprintf("%s=%v", k, v))
+		}
+		targetURL += "?" + strings.Join(params, "&")
+	}
+
+	// Forward only the Request body to mc-infra-manager
+	bodyBytes, err := json.Marshal(req.Request)
+	if err != nil {
+		return respondCmdError(c, http.StatusInternalServerError, "failed to marshal request: "+err.Error())
+	}
+
+	httpReq, err := http.NewRequest(http.MethodPost, targetURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return respondCmdError(c, http.StatusInternalServerError, "failed to build request: "+err.Error())
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.SetBasicAuth(INFRA_MANAGER_USER, INFRA_MANAGER_PASS)
+
+	client := &http.Client{}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return respondCmdError(c, http.StatusBadGateway, "failed to reach mc-infra-manager: "+err.Error())
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	var responseData interface{}
+	if jsonErr := json.Unmarshal(respBody, &responseData); jsonErr != nil {
+		responseData = strings.TrimSpace(string(respBody))
+	}
+
+	return c.JSON(resp.StatusCode, map[string]interface{}{
+		"responseData": responseData,
+		"status": map[string]interface{}{
+			"code":    resp.StatusCode,
+			"message": http.StatusText(resp.StatusCode),
+		},
+	})
+}
+
+func respondCmdError(c echo.Context, code int, msg string) error {
+	return c.JSON(code, map[string]interface{}{
+		"responseData": map[string]string{"message": msg},
+		"status":       map[string]interface{}{"code": code, "message": http.StatusText(code)},
+	})
+}

--- a/front/actions/env.go
+++ b/front/actions/env.go
@@ -11,6 +11,9 @@ var API_SCHEME string
 var API_ADDR string
 var API_PORT string
 var SESSION_SECRET string
+var INFRA_MANAGER_URL string
+var INFRA_MANAGER_USER string
+var INFRA_MANAGER_PASS string
 
 func init() {
 	// Get environment variables with defaults
@@ -20,6 +23,9 @@ func init() {
 	API_ADDR = getEnvOrDefault("MC_WEB_CONSOLE_API_ADDR", "localhost")
 	API_PORT = getEnvOrDefault("MC_WEB_CONSOLE_API_PORT", "3000")
 	SESSION_SECRET = getEnvOrDefault("MC_WEB_CONSOLE_SESSION_SECRET", "mc-web-console-secret-key")
+	INFRA_MANAGER_URL = getEnvOrDefault("MC_WEB_CONSOLE_INFRA_MANAGER_URL", "http://localhost:1323/tumblebug")
+	INFRA_MANAGER_USER = getEnvOrDefault("MC_WEB_CONSOLE_INFRA_MANAGER_USER", "default")
+	INFRA_MANAGER_PASS = getEnvOrDefault("MC_WEB_CONSOLE_INFRA_MANAGER_PASS", "default")
 }
 
 func getEnvOrDefault(key, defaultValue string) string {

--- a/front/actions/upload.go
+++ b/front/actions/upload.go
@@ -1,0 +1,144 @@
+package actions
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+)
+
+type fileUploadPathParams struct {
+	NsId    string `json:"nsId"`
+	InfraId string `json:"infraId"`
+}
+
+type fileUploadFileInfo struct {
+	Name string `json:"name"`
+	Data string `json:"data"`
+	Type string `json:"type"`
+}
+
+type fileUploadRequestBody struct {
+	Path string             `json:"path"`
+	File fileUploadFileInfo `json:"file"`
+}
+
+type fileUploadCommonRequest struct {
+	PathParams  fileUploadPathParams   `json:"pathParams"`
+	QueryParams map[string]interface{} `json:"queryParams"`
+	Request     fileUploadRequestBody  `json:"request"`
+}
+
+// PostFileToInfraHandler handles file transfer to mc-infra-manager.
+// The JS sends JSON with base64-encoded file; this handler converts it to
+// multipart/form-data as required by mc-infra-manager's transferFile API.
+func PostFileToInfraHandler(c echo.Context) error {
+	var req fileUploadCommonRequest
+	if err := json.NewDecoder(c.Request().Body).Decode(&req); err != nil {
+		return respondUploadError(c, http.StatusBadRequest, "invalid request body: "+err.Error())
+	}
+
+	nsId := req.PathParams.NsId
+	infraId := req.PathParams.InfraId
+	if nsId == "" || infraId == "" {
+		return respondUploadError(c, http.StatusBadRequest, "nsId and infraId are required")
+	}
+
+	targetPath := req.Request.Path
+	if targetPath == "" {
+		return respondUploadError(c, http.StatusBadRequest, "target path is required")
+	}
+
+	// Decode base64 file (supports data URL format: "data:...;base64,<data>")
+	rawData := req.Request.File.Data
+	if idx := strings.Index(rawData, ","); idx >= 0 {
+		rawData = rawData[idx+1:]
+	}
+	// Normalize base64: remove whitespace, handle URL-safe variant
+	rawData = strings.TrimSpace(rawData)
+	fileBytes, err := base64.StdEncoding.DecodeString(rawData)
+	if err != nil {
+		fileBytes, err = base64.URLEncoding.DecodeString(rawData)
+		if err != nil {
+			return respondUploadError(c, http.StatusBadRequest, "failed to decode file data: "+err.Error())
+		}
+	}
+
+	fileName := req.Request.File.Name
+	if fileName == "" {
+		fileName = "upload"
+	}
+
+	// Build multipart/form-data body
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	if err := writer.WriteField("path", targetPath); err != nil {
+		return respondUploadError(c, http.StatusInternalServerError, "failed to write form field")
+	}
+
+	part, err := writer.CreateFormFile("file", fileName)
+	if err != nil {
+		return respondUploadError(c, http.StatusInternalServerError, "failed to create form file")
+	}
+	if _, err := part.Write(fileBytes); err != nil {
+		return respondUploadError(c, http.StatusInternalServerError, "failed to write file data")
+	}
+	writer.Close()
+
+	// Build target URL with path substitution
+	targetURL := fmt.Sprintf("%s/ns/%s/transferFile/infra/%s", INFRA_MANAGER_URL, nsId, infraId)
+
+	// Forward queryParams as URL query string (e.g. subGroupId, vmId)
+	if len(req.QueryParams) > 0 {
+		params := []string{}
+		for k, v := range req.QueryParams {
+			params = append(params, fmt.Sprintf("%s=%v", k, v))
+		}
+		targetURL += "?" + strings.Join(params, "&")
+	}
+
+	httpReq, err := http.NewRequest(http.MethodPost, targetURL, &body)
+	if err != nil {
+		return respondUploadError(c, http.StatusInternalServerError, "failed to build request: "+err.Error())
+	}
+	httpReq.Header.Set("Content-Type", writer.FormDataContentType())
+
+	// Use Basic auth for mc-infra-manager (cb-tumblebug)
+	httpReq.SetBasicAuth(INFRA_MANAGER_USER, INFRA_MANAGER_PASS)
+
+	client := &http.Client{}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return respondUploadError(c, http.StatusBadGateway, "failed to reach mc-infra-manager: "+err.Error())
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	var responseData interface{}
+	if jsonErr := json.Unmarshal(respBody, &responseData); jsonErr != nil {
+		responseData = strings.TrimSpace(string(respBody))
+	}
+
+	return c.JSON(resp.StatusCode, map[string]interface{}{
+		"responseData": responseData,
+		"status": map[string]interface{}{
+			"code":    resp.StatusCode,
+			"message": http.StatusText(resp.StatusCode),
+		},
+	})
+}
+
+func respondUploadError(c echo.Context, code int, msg string) error {
+	return c.JSON(code, map[string]interface{}{
+		"responseData": map[string]string{"message": msg},
+		"status":       map[string]interface{}{"code": code, "message": http.StatusText(code)},
+	})
+}

--- a/front/assets/js/common/api/services/remotecmd_api.js
+++ b/front/assets/js/common/api/services/remotecmd_api.js
@@ -10,7 +10,7 @@ export async function postRemoteCmd(nsid, resourceId, targetId, cmdarr, targetTy
         data = {
             pathParams: {
                 nsId: nsid,
-                mciId: resourceId
+                infraId: resourceId
             },
             queryParams: {
                 vmId: targetId
@@ -25,7 +25,7 @@ export async function postRemoteCmd(nsid, resourceId, targetId, cmdarr, targetTy
         data = {
             pathParams: {
                 nsId: nsid,
-                mciId: resourceId
+                infraId: resourceId
             },
             queryParams: {
                 subGroupId: targetId
@@ -36,11 +36,11 @@ export async function postRemoteCmd(nsid, resourceId, targetId, cmdarr, targetTy
             }
         };
     } else if (targetType === 'mci') {
-        // MCI 로직 - queryParams 불필요 (pathParams에 이미 mciId 포함)
+        // MCI 로직 - queryParams 불필요 (pathParams에 이미 infraId 포함)
         data = {
             pathParams: {
                 nsId: nsid,
-                mciId: resourceId
+                infraId: resourceId
             },
             Request: {
                 command: cmdarr,
@@ -97,7 +97,7 @@ export async function postFileToMci(nsId, mciId, file, targetPath, targetType, t
     let data = {
         pathParams: {
             nsId: nsId,
-            mciId: mciId
+            infraId: mciId
         },
         request: {
             path: targetPath,

--- a/front/assets/js/common/iframe/iframe.js
+++ b/front/assets/js/common/iframe/iframe.js
@@ -22,8 +22,10 @@ function resolveIframeUrl(baseURL) {
         const path = rawPath === '/' ? '' : rawPath;
         const isLocalhost = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
 
-        // Docker 내부 hostname (점 없음): 브라우저 hostname + protocol로 대체
-        if (!urlObj.hostname.includes('.')) {
+        const isIpAddress = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(urlObj.hostname);
+
+        // Docker 내부 hostname (점 없음) 또는 IP 주소: 브라우저 hostname + protocol로 대체
+        if (!urlObj.hostname.includes('.') || isIpAddress) {
             if (isLocalhost) {
                 return 'http://' + window.location.hostname + port + path;
             }

--- a/front/assets/js/pages/operation/manage/mci.js
+++ b/front/assets/js/pages/operation/manage/mci.js
@@ -2611,7 +2611,7 @@ async function loadPolicyData() {
 // API 응답을 테이블 형식으로 가공
 function transformPolicyResponse(resp) {
   const list = [];
-  resp.mciPolicy.forEach(mci => {
+  resp.infraPolicy.forEach(mci => {
     const { Id: mciId, Name: mciName, actionLog, description } = mci;
 
     mci.policy.forEach(pol => {

--- a/front/assets/js/pages/operation/plugins/softwaremanager.iframe.js
+++ b/front/assets/js/pages/operation/plugins/softwaremanager.iframe.js
@@ -37,6 +37,13 @@ async function loadSoftwareManager() {
     }
 
     const data = getSoftwareManagerData();
+
+    // mc-application-manager API URL을 레지스트리에서 직접 조회하여 전달
+    var apiHost = await webconsolejs["common/iframe/iframe"].GetApiHosts("mc-application-manager");
+    if (apiHost) {
+        data.apiBaseUrl = apiHost;
+    }
+
     webconsolejs["common/iframe/iframe"].addIframe("targetIframe-sofrwareCatalog", host + "/web/softwareCatalog", data);
 }
 


### PR DESCRIPTION
## Summary

- MCI workload 화면 Remote Terminal 기능 버그 수정

## Key Bug Fixes

- **PostCmdInfra 400 오류**: `pathParams.mciId` → `pathParams.infraId` 수정 (`remotecmd_api.js`)
- **Policy 탭 TypeError**: `resp.mciPolicy` → `resp.infraPolicy` 수정 (`mci.js`)
- **PostFileToInfra 파일 전송**: JSON+base64 → multipart/form-data 변환 핸들러 추가 (`upload.go`)
  - mc-infra-manager가 `multipart/form-data` 요구 → 로컬 front 서버에서 변환 후 직접 호출
- **GetInfraNode pathParams**: 경로 파라미터 수정
