### PR TITLE
fix: PMK 화면에서 project 변경 후 행 클릭 시 nsId 갱신 오류 수정

### DIFF
--- a/front/assets/js/pages/operation/manage/pmk.js
+++ b/front/assets/js/pages/operation/manage/pmk.js
@@ -90,6 +90,9 @@ $("#select-current-project").on('change', async function () {
         "NsId": nsFromAttr || (opt ? opt.textContent : '')
     };
     webconsolejs["common/api/services/workspace_api"].setCurrentProject(project)// 세션에 저장
+    selectedWorkspaceProject.projectId = project.Id;
+    selectedWorkspaceProject.projectName = project.Name;
+    selectedWorkspaceProject.nsId = project.NsId;
     // Using direct API call with default page loader for project change
     var respPmkList = await webconsolejs["common/api/services/pmk_api"].getClusterList(project.NsId);
     getPmkListCallbackSuccess(project.NsId, respPmkList);


### PR DESCRIPTION
## Summary

- `#select-current-project` onChange 핸들러가 PMK 목록은 갱신하지만 `selectedWorkspaceProject.nsId`를 갱신하지 않아, 이후 행 클릭 시 `nsId = ""`로 API 호출 → 400 오류 발생
- onChange 시 `selectedWorkspaceProject.projectId / projectName / nsId`를 함께 갱신하도록 수정
