### PR TITLE
fix: observability iframe 높이 부족 수정

### DIFF
--- a/front/assets/js/pages/operation/plugins/observability.iframe.js
+++ b/front/assets/js/pages/operation/plugins/observability.iframe.js
@@ -22,8 +22,10 @@ async function loadObservability() {
   const currentWorkspace = webconsolejs['common/api/services/workspace_api'].getCurrentWorkspace();
   const currentProject = webconsolejs['common/api/services/workspace_api'].getCurrentProject();
   const targetDiv = document.getElementById('targetIframe-observability');
+  const bannerDiv = document.getElementById('observability-cert-banner');
 
   if (!currentWorkspace || !currentWorkspace.Id || !currentProject || !currentProject.Id) {
+    bannerDiv.innerHTML = '';
     targetDiv.innerHTML =
       '<div class="alert alert-warning m-3">Please select a Workspace and Project.</div>';
     return;
@@ -31,6 +33,7 @@ async function loadObservability() {
 
   const host = await webconsolejs['common/iframe/iframe'].GetApiHosts('mc-observability-fe');
   if (!host) {
+    bannerDiv.innerHTML = '';
     targetDiv.innerHTML =
       '<div class="alert alert-warning m-3">mc-observability-fe service URL not found.<br>' +
       'Please register the mc-observability-fe URL in Settings &gt; Environment.</div>';
@@ -41,20 +44,16 @@ async function loadObservability() {
   const data = getObservabilityData();
   const iframeSrc = host + '/embed/monitoring/' + nsId;
 
-  targetDiv.innerHTML = `
+  bannerDiv.innerHTML = `
     <div class="d-flex align-items-center gap-2 p-2 mb-1" style="background:#f8f9fa;border-radius:4px;font-size:0.85rem;">
       <span class="text-muted">접속 주소:</span>
       <a href="${iframeSrc}" target="_blank" class="text-primary">${host}</a>
       <span class="text-muted">— iframe 내용이 보이지 않으면 위 링크에서 인증서를 수락한 후</span>
       <button class="btn btn-sm btn-outline-secondary py-0 px-2" onclick="loadObservability()">새로고침</button>
     </div>
-    <div id="targetIframe-observability-frame" style="flex:1;min-height:0;"></div>
   `;
-  webconsolejs['common/iframe/iframe'].addIframe(
-    'targetIframe-observability-frame',
-    iframeSrc,
-    data
-  );
+  targetDiv.innerHTML = '';
+  webconsolejs['common/iframe/iframe'].addIframe('targetIframe-observability', iframeSrc, data);
 }
 
 $('#select-current-project').on('change', async function () {

--- a/front/templates/pages/operations/analytics/observability.iframe.html
+++ b/front/templates/pages/operations/analytics/observability.iframe.html
@@ -1,3 +1,4 @@
+<div id="observability-cert-banner"></div>
 <div class="iframe-wrapper" id="targetIframe-observability" height="100%"></div>
 
 {{ javascriptTag("common/iframe/iframe.js") | raw }}


### PR DESCRIPTION
## Summary

- observability iframe 페이지에서 인증서 안내 배너가 `.iframe-wrapper` 내부에 삽입되어 iframe 높이가 압축되는 문제 수정
- 배너 div(`#observability-cert-banner`)를 `.iframe-wrapper` 밖으로 분리하여 `iframe { flex-grow: 1 }` CSS가 정상 작동하도록 수정
