### PR TITLE
feat: RecommendSpec Cloud Provider 검색 필터 추가

### DIFF
--- a/front/assets/js/partials/operation/manage/clusterrecommendation.js
+++ b/front/assets/js/partials/operation/manage/clusterrecommendation.js
@@ -457,3 +457,17 @@ async function availableVMImageBySpec(id) {
 
 	return imageIds[0]
 }
+
+if (typeof webconsolejs === 'undefined') {
+	webconsolejs = {};
+}
+if (typeof webconsolejs['partials/operation/manage/clusterrecommendation'] === 'undefined') {
+	webconsolejs['partials/operation/manage/clusterrecommendation'] = {};
+}
+
+webconsolejs['partials/operation/manage/clusterrecommendation'].initClusterRecommendation = initClusterRecommendation;
+webconsolejs['partials/operation/manage/clusterrecommendation'].getRecommendVmInfo = getRecommendVmInfo;
+webconsolejs['partials/operation/manage/clusterrecommendation'].applySpecInfo = applySpecInfo;
+webconsolejs['partials/operation/manage/clusterrecommendation'].showRecommendSpecSetting = showRecommendSpecSetting;
+webconsolejs['partials/operation/manage/clusterrecommendation'].onProviderAllChangeCluster = onProviderAllChangeCluster;
+webconsolejs['partials/operation/manage/clusterrecommendation'].onProviderCheckChangeCluster = onProviderCheckChangeCluster;

--- a/front/assets/js/partials/operation/manage/clusterrecommendation.js
+++ b/front/assets/js/partials/operation/manage/clusterrecommendation.js
@@ -13,6 +13,16 @@ export function initClusterRecommendation(callbackfunction) {
 	if (callbackfunction != undefined) {
 		returnFunction = callbackfunction;
 	}
+
+	// 팝업 열릴 때마다 provider 체크박스 초기화 (All 체크, 나머지 해제)
+	const modalEl = document.getElementById('image-search');
+	if (modalEl) {
+		modalEl.addEventListener('shown.bs.modal', function () {
+			document.querySelectorAll('.spec-provider-check-cluster').forEach(cb => cb.checked = false);
+			const allCb = document.getElementById('spec-provider-all-cluster');
+			if (allCb) allCb.checked = true;
+		});
+	}
 }
 
 function initRecommendSpecTable() {
@@ -305,6 +315,19 @@ export async function getRecommendVmInfo() {
 		policyArr.push(filterPolicy)
 	}
 
+	// provider filter
+	const allProviderCheckedCluster = document.getElementById('spec-provider-all-cluster')?.checked !== false;
+	if (!allProviderCheckedCluster) {
+		const selectedProviders = [...document.querySelectorAll('.spec-provider-check-cluster:checked')]
+			.map(cb => cb.value);
+		if (selectedProviders.length > 0) {
+			policyArr.push({
+				"metric": "providerName",
+				"condition": selectedProviders.map(p => ({ "operator": "==", "operand": p }))
+			});
+		}
+	}
+
 	//
 	var priorityArr = new Array();
 
@@ -341,7 +364,6 @@ export async function getRecommendVmInfo() {
 		return
 	}
 
-	// TODO : 선택된 provider 필터
 	recommendVmSpecListObj = respData.responseData
 
 	recommendTable.setData(recommendVmSpecListObj)
@@ -386,6 +408,21 @@ export function showRecommendSpecSetting(value) {
 	}
 }
 
+
+export function onProviderAllChangeCluster(allCheckbox) {
+	if (allCheckbox.checked) {
+		document.querySelectorAll('.spec-provider-check-cluster').forEach(cb => cb.checked = false);
+	} else {
+		const anyChecked = [...document.querySelectorAll('.spec-provider-check-cluster')].some(cb => cb.checked);
+		if (!anyChecked) allCheckbox.checked = true;
+	}
+}
+
+export function onProviderCheckChangeCluster() {
+	const anyChecked = [...document.querySelectorAll('.spec-provider-check-cluster')].some(cb => cb.checked);
+	const allCb = document.getElementById('spec-provider-all-cluster');
+	if (allCb) allCb.checked = !anyChecked;
+}
 
 // TODO: 스펙 선택 시 사용가능한 이미지의 개수가 두개 이상일 때 선택하는 UI 추가 구현 필요
 async function availableVMImageBySpec(id) {

--- a/front/assets/js/partials/operation/manage/pmk_serverrecommendation.js
+++ b/front/assets/js/partials/operation/manage/pmk_serverrecommendation.js
@@ -13,15 +13,18 @@ export function initServerRecommendationPmk(callbackfunction) {
 	if (callbackfunction != undefined) {
 		returnFunctionPmk = callbackfunction;
 	}
-	
-	// 모달 열기 이벤트 리스너 등록
-	setupServerModalEventsPmk();
-}
 
-// PMK용 서버 추천 모달 이벤트 설정
-function setupServerModalEventsPmk() {
-	// Provider 옵션은 HTML partial component로 이미 렌더링됨
-	// 추가 초기화가 필요한 경우 여기에 작성
+	// 팝업 열릴 때마다 선택된 provider를 배지에 표시
+	const modalEl = document.getElementById('spec-search-pmk');
+	if (modalEl) {
+		modalEl.addEventListener('shown.bs.modal', function () {
+			const provider = document.getElementById('cluster_provider_dynamic')?.value || '';
+			const badge = document.getElementById('spec-provider-badge-pmk');
+			const hidden = document.getElementById('spec-provider-value-pmk');
+			if (badge) badge.textContent = provider;
+			if (hidden) hidden.value = provider;
+		});
+	}
 }
 
 function initRecommendSpecTablePmk() {
@@ -234,7 +237,16 @@ export async function getRecommendVmInfoPmk() {
 			}
 			policyArr.push(filterPolicy)
 		}
-		
+
+		// provider 필터 - 폼에서 선택된 provider 값 적용
+		const selectedProvider = document.getElementById('spec-provider-value-pmk')?.value;
+		if (selectedProvider) {
+			policyArr.push({
+				"metric": "providerName",
+				"condition": [{ "operator": "==", "operand": selectedProvider }]
+			});
+		}
+
 		// 우선순위 정책 설정
 		const priorityArr = [];
 		if (lat && lon) {

--- a/front/assets/js/partials/operation/manage/serverrecommendation.js
+++ b/front/assets/js/partials/operation/manage/serverrecommendation.js
@@ -13,6 +13,16 @@ export function initServerRecommendation(callbackfunction) {
 	if (callbackfunction != undefined) {
 		returnFunction = callbackfunction;
 	}
+
+	// 팝업 열릴 때마다 provider 체크박스 초기화 (All 체크, 나머지 해제)
+	const modalEl = document.getElementById('spec-search');
+	if (modalEl) {
+		modalEl.addEventListener('shown.bs.modal', function () {
+			document.querySelectorAll('.spec-provider-check').forEach(cb => cb.checked = false);
+			const allCb = document.getElementById('spec-provider-all');
+			if (allCb) allCb.checked = true;
+		});
+	}
 }
 
 function initRecommendSpecTable() {
@@ -388,6 +398,19 @@ export async function getRecommendVmInfo() {
 		policyArr.push(filterPolicy)
 	}
 
+	// provider filter
+	const allProviderChecked = document.getElementById('spec-provider-all')?.checked !== false;
+	if (!allProviderChecked) {
+		const selectedProviders = [...document.querySelectorAll('.spec-provider-check:checked')]
+			.map(cb => cb.value);
+		if (selectedProviders.length > 0) {
+			policyArr.push({
+				"metric": "providerName",
+				"condition": selectedProviders.map(p => ({ "operator": "==", "operand": p }))
+			});
+		}
+	}
+
 	//
 	var priorityArr = new Array();
 
@@ -538,24 +561,34 @@ async function availableVMImageBySpec(id) {
 }
 */
 
-// 프로바이더별 필터링 기능
 export function filterByProvider(provider) {
-	
 	if (!recommendVmSpecListObj || recommendVmSpecListObj.length === 0) {
-		console.error("No data to filter - no search results available");
 		return;
 	}
-	
 	if (provider === "") {
-		// 모든 프로바이더 표시
 		recommendTable.setData(recommendVmSpecListObj);
 	} else {
-		// 선택된 프로바이더만 필터링
 		var filteredData = recommendVmSpecListObj.filter(function(item) {
 			return item.providerName && item.providerName.toLowerCase() === provider.toLowerCase();
 		});
 		recommendTable.setData(filteredData);
 	}
+}
+
+export function onProviderAllChange(allCheckbox) {
+	if (allCheckbox.checked) {
+		document.querySelectorAll('.spec-provider-check').forEach(cb => cb.checked = false);
+	} else {
+		// All을 직접 해제하면 아무것도 선택 안 된 상태 방지 — All로 복원
+		const anyChecked = [...document.querySelectorAll('.spec-provider-check')].some(cb => cb.checked);
+		if (!anyChecked) allCheckbox.checked = true;
+	}
+}
+
+export function onProviderCheckChange() {
+	const anyChecked = [...document.querySelectorAll('.spec-provider-check')].some(cb => cb.checked);
+	const allCb = document.getElementById('spec-provider-all');
+	if (allCb) allCb.checked = !anyChecked;
 }
 
 // 전역 객체에 함수 등록
@@ -571,3 +604,5 @@ webconsolejs['partials/operation/manage/serverrecommendation'].getRecommendVmInf
 webconsolejs['partials/operation/manage/serverrecommendation'].applySpecInfo = applySpecInfo;
 webconsolejs['partials/operation/manage/serverrecommendation'].showRecommendSpecSetting = showRecommendSpecSetting;
 webconsolejs['partials/operation/manage/serverrecommendation'].filterByProvider = filterByProvider;
+webconsolejs['partials/operation/manage/serverrecommendation'].onProviderAllChange = onProviderAllChange;
+webconsolejs['partials/operation/manage/serverrecommendation'].onProviderCheckChange = onProviderCheckChange;

--- a/front/templates/partials/operation/manage/_clusterrecommendation.html
+++ b/front/templates/partials/operation/manage/_clusterrecommendation.html
@@ -78,6 +78,68 @@
             </div>
           </div>
         </div>
+        <div class="row mt-2">
+          <div class="col-12">
+            <label class="form-label mb-1">Cloud Provider</label>
+            <div class="d-flex flex-wrap gap-3">
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" id="spec-provider-all-cluster" value="all" checked
+                  onchange="webconsolejs['partials/operation/manage/clusterrecommendation'].onProviderAllChangeCluster(this)">
+                <label class="form-check-label fw-semibold" for="spec-provider-all-cluster">All</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input spec-provider-check-cluster" type="checkbox" id="spec-provider-aws-cluster" value="aws"
+                  onchange="webconsolejs['partials/operation/manage/clusterrecommendation'].onProviderCheckChangeCluster()">
+                <label class="form-check-label" for="spec-provider-aws-cluster">AWS</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input spec-provider-check-cluster" type="checkbox" id="spec-provider-azure-cluster" value="azure"
+                  onchange="webconsolejs['partials/operation/manage/clusterrecommendation'].onProviderCheckChangeCluster()">
+                <label class="form-check-label" for="spec-provider-azure-cluster">Azure</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input spec-provider-check-cluster" type="checkbox" id="spec-provider-alibaba-cluster" value="alibaba"
+                  onchange="webconsolejs['partials/operation/manage/clusterrecommendation'].onProviderCheckChangeCluster()">
+                <label class="form-check-label" for="spec-provider-alibaba-cluster">Alibaba</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input spec-provider-check-cluster" type="checkbox" id="spec-provider-gcp-cluster" value="gcp"
+                  onchange="webconsolejs['partials/operation/manage/clusterrecommendation'].onProviderCheckChangeCluster()">
+                <label class="form-check-label" for="spec-provider-gcp-cluster">GCP</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input spec-provider-check-cluster" type="checkbox" id="spec-provider-tencent-cluster" value="tencent"
+                  onchange="webconsolejs['partials/operation/manage/clusterrecommendation'].onProviderCheckChangeCluster()">
+                <label class="form-check-label" for="spec-provider-tencent-cluster">Tencent</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input spec-provider-check-cluster" type="checkbox" id="spec-provider-ncp-cluster" value="ncp"
+                  onchange="webconsolejs['partials/operation/manage/clusterrecommendation'].onProviderCheckChangeCluster()">
+                <label class="form-check-label" for="spec-provider-ncp-cluster">NCP</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input spec-provider-check-cluster" type="checkbox" id="spec-provider-nhn-cluster" value="nhn"
+                  onchange="webconsolejs['partials/operation/manage/clusterrecommendation'].onProviderCheckChangeCluster()">
+                <label class="form-check-label" for="spec-provider-nhn-cluster">NHN</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input spec-provider-check-cluster" type="checkbox" id="spec-provider-ibm-cluster" value="ibm"
+                  onchange="webconsolejs['partials/operation/manage/clusterrecommendation'].onProviderCheckChangeCluster()">
+                <label class="form-check-label" for="spec-provider-ibm-cluster">IBM</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input spec-provider-check-cluster" type="checkbox" id="spec-provider-kt-cluster" value="kt"
+                  onchange="webconsolejs['partials/operation/manage/clusterrecommendation'].onProviderCheckChangeCluster()">
+                <label class="form-check-label" for="spec-provider-kt-cluster">KT</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input spec-provider-check-cluster" type="checkbox" id="spec-provider-openstack-cluster" value="openstack"
+                  onchange="webconsolejs['partials/operation/manage/clusterrecommendation'].onProviderCheckChangeCluster()">
+                <label class="form-check-label" for="spec-provider-openstack-cluster">OpenStack</label>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
 
       <div class="accordion">

--- a/front/templates/partials/operation/manage/_pmk_serverrecommendation.html
+++ b/front/templates/partials/operation/manage/_pmk_serverrecommendation.html
@@ -66,6 +66,15 @@
             </div>
           </div>
         </div>
+        <div class="row mt-2">
+          <div class="col-12">
+            <label class="form-label mb-1">Cloud Provider</label>
+            <div>
+              <span id="spec-provider-badge-pmk" class="badge bg-blue text-white" style="font-size:0.9rem;"></span>
+              <input type="hidden" id="spec-provider-value-pmk" value="">
+            </div>
+          </div>
+        </div>
       </div>
 
       <div class="accordion">

--- a/front/templates/partials/operation/manage/_serverrecommendation.html
+++ b/front/templates/partials/operation/manage/_serverrecommendation.html
@@ -66,6 +66,68 @@
             </div>
           </div>
         </div>
+        <div class="row mt-2">
+          <div class="col-12">
+            <label class="form-label mb-1">Cloud Provider</label>
+            <div class="d-flex flex-wrap gap-3">
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" id="spec-provider-all" value="all" checked
+                  onchange="webconsolejs['partials/operation/manage/serverrecommendation'].onProviderAllChange(this)">
+                <label class="form-check-label fw-semibold" for="spec-provider-all">All</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input spec-provider-check" type="checkbox" id="spec-provider-aws" value="aws"
+                  onchange="webconsolejs['partials/operation/manage/serverrecommendation'].onProviderCheckChange()">
+                <label class="form-check-label" for="spec-provider-aws">AWS</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input spec-provider-check" type="checkbox" id="spec-provider-azure" value="azure"
+                  onchange="webconsolejs['partials/operation/manage/serverrecommendation'].onProviderCheckChange()">
+                <label class="form-check-label" for="spec-provider-azure">Azure</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input spec-provider-check" type="checkbox" id="spec-provider-alibaba" value="alibaba"
+                  onchange="webconsolejs['partials/operation/manage/serverrecommendation'].onProviderCheckChange()">
+                <label class="form-check-label" for="spec-provider-alibaba">Alibaba</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input spec-provider-check" type="checkbox" id="spec-provider-gcp" value="gcp"
+                  onchange="webconsolejs['partials/operation/manage/serverrecommendation'].onProviderCheckChange()">
+                <label class="form-check-label" for="spec-provider-gcp">GCP</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input spec-provider-check" type="checkbox" id="spec-provider-tencent" value="tencent"
+                  onchange="webconsolejs['partials/operation/manage/serverrecommendation'].onProviderCheckChange()">
+                <label class="form-check-label" for="spec-provider-tencent">Tencent</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input spec-provider-check" type="checkbox" id="spec-provider-ncp" value="ncp"
+                  onchange="webconsolejs['partials/operation/manage/serverrecommendation'].onProviderCheckChange()">
+                <label class="form-check-label" for="spec-provider-ncp">NCP</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input spec-provider-check" type="checkbox" id="spec-provider-nhn" value="nhn"
+                  onchange="webconsolejs['partials/operation/manage/serverrecommendation'].onProviderCheckChange()">
+                <label class="form-check-label" for="spec-provider-nhn">NHN</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input spec-provider-check" type="checkbox" id="spec-provider-ibm" value="ibm"
+                  onchange="webconsolejs['partials/operation/manage/serverrecommendation'].onProviderCheckChange()">
+                <label class="form-check-label" for="spec-provider-ibm">IBM</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input spec-provider-check" type="checkbox" id="spec-provider-kt" value="kt"
+                  onchange="webconsolejs['partials/operation/manage/serverrecommendation'].onProviderCheckChange()">
+                <label class="form-check-label" for="spec-provider-kt">KT</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input spec-provider-check" type="checkbox" id="spec-provider-openstack" value="openstack"
+                  onchange="webconsolejs['partials/operation/manage/serverrecommendation'].onProviderCheckChange()">
+                <label class="form-check-label" for="spec-provider-openstack">OpenStack</label>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
 
       <div class="accordion">


### PR DESCRIPTION
## Summary
RecommendSpec 에서 Top 1000  밖에있는 spec이 누락되어 원하는 provider 검색을 위하여 filter 추가

- MCI/Cluster/PMK RecommendSpec 팝업에 Cloud Provider 멀티체크박스 검색 필터 추가 (AWS, Azure, GCP, NCP, KT, OpenStack 등)
- Cluster recommendation HTML에서 호출하는 provider 변경 핸들러를 webconsolejs 전역 네임스페이스에 등록해 런타임 오류 수정
- PMK Spec Recommendation 팝업 오픈 시 선택된 Cloud Provider를 배지로 표시하고 검색 시 providerName 필터 자동 적용
