### PR TITLE
feat: mc-infra-manager v0.12 대응 및 안정성 개선

### DIFF
--- a/front/assets/js/common/api/services/pmk_api.js
+++ b/front/assets/js/common/api/services/pmk_api.js
@@ -129,7 +129,7 @@ export async function CreateCluster(clusterName, selectedConnection, clusterVers
 
   // 생성요청했으므로 결과를 기다리지 않고 pmkList로 보냄
   // webconsolejs["common/util"].changePage("PmkMng", urlParamMap)
-  window.location = "/webconsole/operations/manage/workloads/pmkwls"
+  window.location = "/webconsole/operations/manage/workloads/pmkworkloads"
 }
 
 export async function getVpcList(connectionName, nsId) {


### PR DESCRIPTION
## Summary

- mc-infra-manager v0.12 API pathParam 및 operationId 불일치 수정
- MCI Group 탭 서브그룹이 `undefined`로 표시되는 버그 수정 (web-bug-017)
- JWT 만료 전 proactive access token refresh 기능 추가 (5분 간격)

## Test plan

- [ ] MCI Group 탭에서 서브그룹 ID가 올바르게 표시되는지 확인
- [ ] 장시간 세션 유지 시 토큰 자동 갱신 여부 확인