### PR TITLE
sync: MZC-CSC/mc-web-console develop → m-cmp/mc-web-console main

### DIFF
--- a/front/assets/js/common/api/services/pmk_api.js
+++ b/front/assets/js/common/api/services/pmk_api.js
@@ -496,11 +496,21 @@ export async function getAvailablek8sClusterNodeImage(providerName, regionName) 
 }
 
 // connectionName에 맞는 K8s 노드 spec을 동적 조회 (RecommendK8sNode)
-// connectionName이 일치하는 첫 번째 specId를 반환; 없거나 오류 시 ""
+// tumblebug가 connectionName을 서버 사이드 필터로 지원하므로(FilterSpecsByRangeRequest.ConnectionName),
+// 클라이언트에서 결과를 사후 필터링하지 않고 요청 단계에서 정확히 필터링한다.
+// 일치하는 첫 번째 specId를 반환; 없거나 오류 시 ""
 export async function getRecommendedK8sSpecId(connectionName) {
   const data = {
     request: {
-      limit: 200
+      filter: {
+        policy: [
+          {
+            metric: "connectionName",
+            condition: [{ operator: "==", operand: connectionName }]
+          }
+        ]
+      },
+      limit: 50
     }
   };
 
@@ -516,10 +526,9 @@ export async function getRecommendedK8sSpecId(connectionName) {
     }
 
     const specs = response.data.responseData;
-    if (!Array.isArray(specs)) return "";
+    if (!Array.isArray(specs) || specs.length === 0) return "";
 
-    const matched = specs.find(spec => spec.connectionName === connectionName);
-    return matched ? (matched.id || "") : "";
+    return specs[0].id || "";
   } catch (e) {
     return "";
   }

--- a/front/assets/js/pages/operation/manage/pmk.js
+++ b/front/assets/js/pages/operation/manage/pmk.js
@@ -1644,24 +1644,17 @@ export async function deployPmkDynamic() {
                 k8sVersion = versions[0].id || "";
             }
 
-            // provider 컨텍스트용 specId: RecommendK8sNode 조회 → 없으면 CSP별 하드코딩 fallback
+            // provider 컨텍스트용 specId: RecommendK8sNode를 connectionName으로 서버 사이드 필터링하여 조회
             commonSpec = await webconsolejs["common/api/services/pmk_api"]
                 .getRecommendedK8sSpecId(clusterData.connection);
             if (!commonSpec) {
-                const K8S_DEFAULT_SPEC = {
-                    'aws':     't3.medium',
-                    'azure':   'Standard_B2s',
-                    'gcp':     'n1-standard-2',
-                    'alibaba': 'ecs.c1.small',
-                    'ncp':     'SVR.VSVR.STAND.C002.M004.NET.SSD.B050.G002',
-                    'nhncloud': 'm2.c4m8',
-                    'ibm':     'cx2-4x8',
-                };
-                const sepIdx = clusterData.connection.indexOf('-');
-                const csp = clusterData.connection.substring(0, sepIdx).toLowerCase();
-                const region = clusterData.connection.substring(sepIdx + 1);
-                const instanceType = K8S_DEFAULT_SPEC[csp] || 't3.medium';
-                commonSpec = `${csp}+${region}+${instanceType}`;
+                // 하드코딩된 fallback 스펙은 리전마다 유효성이 달라 항상 실패할 수 있으므로 사용하지 않는다.
+                // 대신 실패 원인을 명확히 알리고 중단한다.
+                webconsolejs['common/util'].showToast(
+                    `No available spec found for connection '${clusterData.connection}'. Please check if specs are registered/synced for this connection.`,
+                    'error'
+                );
+                return;
             }
 
             commonImage = "default";


### PR DESCRIPTION
## Summary

- refactor(plugins): iframe 플러그인 JS 패턴 통일 (#206)
- fix: mc-infra-manager path params 업데이트 (mciId→infraId, vmId→nodeId, subgroupId→nodegroupId)
- fix(pmk): Expert Creation NodeGroup Spec 팝업 Provider 미전달 버그 수정 (#204)
- refactor(docs): 개발노트 및 e2e-snapshot 문서 정리 (#202)
- fix(pmk): AutoScaling Off 시 minNodeSize/maxNodeSize 비활성화 및 전송 제외 (#201)
- fix(pmk): onAutoScaling 타입 수정
