### PR TITLE
feat: 문구 변경 (Infra, K8s), Infra 배포로직 고도화, 알림 개선. bug fix

### DIFF
--- a/api/internal/handler/apihosts.go
+++ b/api/internal/handler/apihosts.go
@@ -16,9 +16,11 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// ServiceNoAuth Auth 정보를 제외한 서비스 호스트 정보 (Buffalo ServiceNoAuth 호환)
+// ServiceNoAuth credential(username/password)을 제외한 서비스 호스트 정보 (Buffalo ServiceNoAuth 호환).
+// AuthType은 호출 측이 프레임워크별 인증 방식(basic/bearer)을 선택하는 데 필요해 노출한다.
 type ServiceNoAuth struct {
-	BaseURL string `json:"BaseURL"`
+	BaseURL  string `json:"BaseURL"`
+	AuthType string `json:"AuthType,omitempty"`
 }
 
 // GetApiHosts POST /api/getapihosts
@@ -39,7 +41,7 @@ func GetApiHosts(c echo.Context) error {
 
 	// api.yaml을 기본값으로 사용 (레지스트리 미등록 서비스도 포함)
 	for k, v := range cfg.ApiSpec.Services {
-		apiHosts[k] = ServiceNoAuth{BaseURL: v.BaseURL}
+		apiHosts[k] = ServiceNoAuth{BaseURL: v.BaseURL, AuthType: v.Auth.Type}
 	}
 
 	if cfg.MCIAM.Use && cfg.RegistryCache != nil {
@@ -54,7 +56,11 @@ func GetApiHosts(c echo.Context) error {
 		// 레지스트리 값으로 override (BaseURL이 있는 경우만)
 		for k, v := range cached {
 			if v.BaseURL != "" {
-				apiHosts[k] = ServiceNoAuth{BaseURL: v.BaseURL}
+				authType := v.Auth.Type
+				if authType == "" {
+					authType = apiHosts[k].AuthType
+				}
+				apiHosts[k] = ServiceNoAuth{BaseURL: v.BaseURL, AuthType: authType}
 			}
 		}
 	}

--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -1138,6 +1138,26 @@ serviceActions:
       method: get
       resourcePath: /api/groups/id/{groupId}/platform-roles
       description: 그룹의 Platform Role 목록 조회
+    getCompany:
+      method: get
+      resourcePath: /api/company
+      description: 플랫폼 회사 정보 조회 (싱글톤)
+    createCompany:
+      method: post
+      resourcePath: /api/company
+      description: 플랫폼 회사 정보 생성 (싱글톤, platformAdmin)
+    updateCompany:
+      method: put
+      resourcePath: /api/company
+      description: 플랫폼 회사 이름/설명 수정 (platformAdmin)
+    deactivateCompany:
+      method: delete
+      resourcePath: /api/company
+      description: 플랫폼 회사 비활성화 (platformAdmin, 멱등)
+    activateCompany:
+      method: post
+      resourcePath: /api/company/activate
+      description: 플랫폼 회사 활성화 (platformAdmin, 멱등)
     listCspAccounts:
       method: post
       resourcePath: /api/csp-accounts/list

--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -821,17 +821,17 @@ serviceActions:
       method: post
       resourcePath: /api/permission/file/framework/{framework}
       description: CSV 기반으로 권한을 업데이트 합니다.
-    Getprojectbyid:
+    getProjectByID:
       method: get
-      resourcePath: /api/prj/project/id/{projectId}
+      resourcePath: /api/projects/id/{projectId}
       description: project 단건 조회
-    Updateprojectbyid:
+    updateProject:
       method: put
-      resourcePath: /api/prj/project/id/{projectId}
+      resourcePath: /api/projects/id/{projectId}
       description: project 수정
-    Deleteprojectbyid:
+    deleteProject:
       method: delete
-      resourcePath: /api/prj/project/id/{projectId}
+      resourcePath: /api/projects/id/{projectId}
       description: project 삭제
     deleteWorkspace:
       method: delete

--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -966,6 +966,10 @@ serviceActions:
       method: get
       resourcePath: /api/workspaces/id/{workspaceId}/projects/list
       description: workspace - projects mapping workspace 기준 목록 조회
+    listUserProjectsByWorkspace:
+      method: get
+      resourcePath: /api/users/workspaces/id/{workspaceId}/projects/list
+      description: workspace - projects mapping, 로그인 사용자 본인 소속 workspace만 조회
     listUserWorkspaces:
       method: post
       resourcePath: /api/users/workspaces/list

--- a/front/actions/apihosts.go
+++ b/front/actions/apihosts.go
@@ -1,0 +1,160 @@
+package actions
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+// FrameworkHost getapihosts가 내려주는 프레임워크별 접속 정보.
+// credential은 API 서버가 노출하지 않으므로 BaseURL과 AuthType만 갖는다.
+type FrameworkHost struct {
+	BaseURL  string `json:"BaseURL"`
+	AuthType string `json:"AuthType"`
+}
+
+// apiHostsCache getapihosts 응답 전체 맵의 인메모리 캐시.
+// TTL 이후 재조회하므로 레지스트리(USE_REGISTRY_URL) 주소 변경도 추종한다.
+var apiHostsCache = struct {
+	mu       sync.Mutex
+	hosts    map[string]FrameworkHost
+	storedAt time.Time
+}{}
+
+const apiHostsCacheTTL = 60 * time.Second
+
+// getApiHostsURL front가 이미 아는 API 서버 주소로 getapihosts 엔드포인트를 조립한다.
+// (ApiCaller 리버스 프록시와 동일한 주소 조합 — 신규 설정 불필요)
+func getApiHostsURL() string {
+	return API_SCHEME + "://" + API_ADDR + ":" + API_PORT + "/api/getapihosts"
+}
+
+// fetchApiHosts POST /api/getapihosts 를 호출해 전체 프레임워크 맵을 반환한다.
+// 캐시가 유효하면 원격 호출 없이 캐시를 반환한다.
+func fetchApiHosts(c echo.Context) (map[string]FrameworkHost, error) {
+	apiHostsCache.mu.Lock()
+	if apiHostsCache.hosts != nil && time.Since(apiHostsCache.storedAt) < apiHostsCacheTTL {
+		hosts := apiHostsCache.hosts
+		apiHostsCache.mu.Unlock()
+		return hosts, nil
+	}
+	apiHostsCache.mu.Unlock()
+
+	req, err := http.NewRequest(http.MethodPost, getApiHostsURL(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// 레지스트리 캐시 갱신 경로가 사용자 토큰/쿠키를 쓸 수 있으므로 원 요청 인증 정보를 전달
+	if c != nil {
+		if authorization, _ := c.Get("Authorization").(string); authorization != "" {
+			req.Header.Set("Authorization", authorization)
+		} else if authHeader := c.Request().Header.Get("Authorization"); authHeader != "" {
+			req.Header.Set("Authorization", authHeader)
+		}
+		for _, cookie := range c.Request().Cookies() {
+			req.AddCookie(cookie)
+		}
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("getapihosts returned %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var parsed struct {
+		ResponseData map[string]FrameworkHost `json:"responseData"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, err
+	}
+	if len(parsed.ResponseData) == 0 {
+		return nil, fmt.Errorf("getapihosts returned empty host map")
+	}
+
+	apiHostsCache.mu.Lock()
+	apiHostsCache.hosts = parsed.ResponseData
+	apiHostsCache.storedAt = time.Now()
+	apiHostsCache.mu.Unlock()
+
+	return parsed.ResponseData, nil
+}
+
+// frameworkEnvKey 프레임워크명에서 env 키를 유도한다.
+// mc-infra-manager → MC_WEB_CONSOLE_INFRA_MANAGER (기존 변수명과 호환)
+func frameworkEnvKey(framework string) string {
+	name := strings.TrimPrefix(strings.ToLower(framework), "mc-")
+	name = strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
+	return "MC_WEB_CONSOLE_" + name
+}
+
+// ResolveFramework 프레임워크의 BaseURL과 인증 방식을 해석한다.
+// 우선순위: MC_WEB_CONSOLE_{NAME}_URL env(명시 오버라이드 — 설정된 경우만)
+//   → getapihosts(캐시)  ← 일반 경로. 레지스트리의 backend 주소는 docker 네트워크명이므로
+//     front가 같은 네트워크에 있으면 그대로 도달. 네트워크 밖(로컬 개발 등)에서는 env로 오버라이드
+//   → fallbackURL(+경고 로그)
+func ResolveFramework(c echo.Context, framework, fallbackURL string) (string, string) {
+	if envURL := getEnvOrDefault(frameworkEnvKey(framework)+"_URL", ""); validFrameworkURL(envURL) {
+		return envURL, ""
+	}
+
+	if hosts, err := fetchApiHosts(c); err == nil {
+		if host, ok := hosts[framework]; ok && validFrameworkURL(host.BaseURL) {
+			return host.BaseURL, host.AuthType
+		}
+		log.Printf("[ResolveFramework] %s not found in getapihosts response", framework)
+	} else {
+		log.Printf("[ResolveFramework] getapihosts failed: %v", err)
+	}
+
+	log.Printf("[ResolveFramework] WARNING: falling back to default URL for %s: %s — check API server or set %s_URL",
+		framework, fallbackURL, frameworkEnvKey(framework))
+	return fallbackURL, ""
+}
+
+// validFrameworkURL 토큰/요청을 내보낼 대상 URL의 스킴을 방어적으로 검증한다.
+func validFrameworkURL(rawURL string) bool {
+	return strings.HasPrefix(rawURL, "http://") || strings.HasPrefix(rawURL, "https://")
+}
+
+// applyFrameworkAuth 프레임워크가 요구하는 인증 방식에 맞춰 요청에 인증을 부착한다.
+//   - basic: MC_WEB_CONSOLE_{NAME}_USER/PASS env 계정 (기본 default/default)
+//   - bearer: 원 요청(사용자)의 Authorization 헤더 전달 (basic 대상에는 절대 미전송)
+//   - 그 외: 인증 미부착
+func applyFrameworkAuth(req *http.Request, c echo.Context, framework, authType string) {
+	switch strings.ToLower(authType) {
+	case "basic":
+		user := getEnvOrDefault(frameworkEnvKey(framework)+"_USER", "default")
+		pass := getEnvOrDefault(frameworkEnvKey(framework)+"_PASS", "default")
+		req.SetBasicAuth(user, pass)
+	case "bearer":
+		authorization, _ := c.Get("Authorization").(string)
+		if authorization == "" {
+			authorization = c.Request().Header.Get("Authorization")
+		}
+		if authorization != "" {
+			if !strings.HasPrefix(authorization, "Bearer ") {
+				authorization = "Bearer " + authorization
+			}
+			req.Header.Set("Authorization", authorization)
+		}
+	}
+}

--- a/front/actions/apihosts_test.go
+++ b/front/actions/apihosts_test.go
@@ -1,0 +1,214 @@
+package actions
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+// resetApiHostsCache 각 테스트가 독립적으로 캐시 상태를 제어하도록 초기화한다.
+func resetApiHostsCache() {
+	apiHostsCache.mu.Lock()
+	apiHostsCache.hosts = nil
+	apiHostsCache.storedAt = time.Time{}
+	apiHostsCache.mu.Unlock()
+}
+
+// pointApiToServer 테스트 서버 주소로 API_SCHEME/ADDR/PORT 전역을 임시 변경한다.
+func pointApiToServer(t *testing.T, serverURL string) {
+	t.Helper()
+	parsed, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	origScheme, origAddr, origPort := API_SCHEME, API_ADDR, API_PORT
+	API_SCHEME = parsed.Scheme
+	API_ADDR = parsed.Hostname()
+	API_PORT = parsed.Port()
+	t.Cleanup(func() {
+		API_SCHEME, API_ADDR, API_PORT = origScheme, origAddr, origPort
+	})
+}
+
+func newTestContext() echo.Context {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec)
+}
+
+func newGetApiHostsServer(hosts map[string]FrameworkHost, calls *int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls != nil {
+			*calls++
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"responseData": hosts,
+			"status":       map[string]interface{}{"code": 200, "message": "OK"},
+		})
+	}))
+}
+
+func TestResolveFrameworkFromGetApiHosts(t *testing.T) {
+	resetApiHostsCache()
+	server := newGetApiHostsServer(map[string]FrameworkHost{
+		"mc-infra-manager":       {BaseURL: "http://tumblebug.example:1323/tumblebug", AuthType: "basic"},
+		"mc-application-manager": {BaseURL: "http://appmgr.example:18084", AuthType: ""},
+		"mc-iam-manager":         {BaseURL: "http://iam.example:5000", AuthType: "bearer"},
+	}, nil)
+	defer server.Close()
+	pointApiToServer(t, server.URL)
+
+	baseURL, authType := ResolveFramework(newTestContext(), "mc-infra-manager", "http://localhost:1323/tumblebug")
+	if baseURL != "http://tumblebug.example:1323/tumblebug" || authType != "basic" {
+		t.Fatalf("unexpected resolve result: %s %s", baseURL, authType)
+	}
+
+	// 타 프레임워크명도 같은 캐시로 조회
+	baseURL, authType = ResolveFramework(newTestContext(), "mc-application-manager", "http://fallback")
+	if baseURL != "http://appmgr.example:18084" || authType != "" {
+		t.Fatalf("unexpected resolve result for application-manager: %s %s", baseURL, authType)
+	}
+	baseURL, authType = ResolveFramework(newTestContext(), "mc-iam-manager", "http://fallback")
+	if baseURL != "http://iam.example:5000" || authType != "bearer" {
+		t.Fatalf("unexpected resolve result for iam-manager: %s %s", baseURL, authType)
+	}
+}
+
+func TestResolveFrameworkEnvOverride(t *testing.T) {
+	resetApiHostsCache()
+	// env 오버라이드는 getapihosts가 정상이어도 최우선 적용된다 (네트워크 외부 dev 등)
+	server := newGetApiHostsServer(map[string]FrameworkHost{
+		"mc-infra-manager": {BaseURL: "http://mc-infra-manager:1323/tumblebug", AuthType: "basic"},
+	}, nil)
+	defer server.Close()
+	pointApiToServer(t, server.URL)
+
+	os.Setenv("MC_WEB_CONSOLE_INFRA_MANAGER_URL", "http://env-tumblebug:1323/tumblebug")
+	defer os.Unsetenv("MC_WEB_CONSOLE_INFRA_MANAGER_URL")
+
+	baseURL, authType := ResolveFramework(newTestContext(), "mc-infra-manager", "http://localhost:1323/tumblebug")
+	if baseURL != "http://env-tumblebug:1323/tumblebug" {
+		t.Fatalf("expected env override, got %s", baseURL)
+	}
+	if authType != "" {
+		t.Fatalf("env override must not carry authType, got %s", authType)
+	}
+}
+
+func TestResolveFrameworkFinalFallback(t *testing.T) {
+	resetApiHostsCache()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	pointApiToServer(t, server.URL)
+	server.Close()
+	os.Unsetenv("MC_WEB_CONSOLE_INFRA_MANAGER_URL")
+
+	baseURL, _ := ResolveFramework(newTestContext(), "mc-infra-manager", "http://localhost:1323/tumblebug")
+	if baseURL != "http://localhost:1323/tumblebug" {
+		t.Fatalf("expected final fallback, got %s", baseURL)
+	}
+}
+
+func TestFetchApiHostsCacheTTL(t *testing.T) {
+	resetApiHostsCache()
+	calls := 0
+	server := newGetApiHostsServer(map[string]FrameworkHost{
+		"mc-infra-manager": {BaseURL: "http://tumblebug.example:1323/tumblebug", AuthType: "basic"},
+	}, &calls)
+	defer server.Close()
+	pointApiToServer(t, server.URL)
+
+	for i := 0; i < 3; i++ {
+		if _, err := fetchApiHosts(newTestContext()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 remote call within TTL, got %d", calls)
+	}
+
+	// TTL 만료 시 재조회
+	apiHostsCache.mu.Lock()
+	apiHostsCache.storedAt = time.Now().Add(-2 * apiHostsCacheTTL)
+	apiHostsCache.mu.Unlock()
+	if _, err := fetchApiHosts(newTestContext()); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected refetch after TTL, got %d calls", calls)
+	}
+}
+
+func TestApplyFrameworkAuth(t *testing.T) {
+	// basic: env 계정(기본 default/default)
+	req, _ := http.NewRequest(http.MethodPost, "http://target", nil)
+	applyFrameworkAuth(req, newTestContext(), "mc-infra-manager", "basic")
+	user, pass, ok := req.BasicAuth()
+	if !ok || user != "default" || pass != "default" {
+		t.Fatalf("expected default basic auth, got %s/%s ok=%v", user, pass, ok)
+	}
+
+	// basic: env 계정 오버라이드
+	os.Setenv("MC_WEB_CONSOLE_INFRA_MANAGER_USER", "opuser")
+	os.Setenv("MC_WEB_CONSOLE_INFRA_MANAGER_PASS", "oppass")
+	defer os.Unsetenv("MC_WEB_CONSOLE_INFRA_MANAGER_USER")
+	defer os.Unsetenv("MC_WEB_CONSOLE_INFRA_MANAGER_PASS")
+	req, _ = http.NewRequest(http.MethodPost, "http://target", nil)
+	applyFrameworkAuth(req, newTestContext(), "mc-infra-manager", "basic")
+	if user, pass, _ = req.BasicAuth(); user != "opuser" || pass != "oppass" {
+		t.Fatalf("expected env basic auth override, got %s/%s", user, pass)
+	}
+
+	// bearer: 원 요청 Authorization 전달
+	c := newTestContext()
+	c.Request().Header.Set("Authorization", "Bearer user-token")
+	req, _ = http.NewRequest(http.MethodPost, "http://target", nil)
+	applyFrameworkAuth(req, c, "mc-infra-manager", "bearer")
+	if got := req.Header.Get("Authorization"); got != "Bearer user-token" {
+		t.Fatalf("expected bearer forwarding, got %q", got)
+	}
+
+	// 인증 없음: 아무것도 부착하지 않음 (basic 대상 외 Bearer 미전송 규칙 포함)
+	c = newTestContext()
+	c.Request().Header.Set("Authorization", "Bearer user-token")
+	req, _ = http.NewRequest(http.MethodPost, "http://target", nil)
+	applyFrameworkAuth(req, c, "mc-application-manager", "")
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Fatalf("expected no auth header, got %q", got)
+	}
+}
+
+func TestFrameworkEnvKey(t *testing.T) {
+	cases := map[string]string{
+		"mc-infra-manager":       "MC_WEB_CONSOLE_INFRA_MANAGER",
+		"mc-application-manager": "MC_WEB_CONSOLE_APPLICATION_MANAGER",
+		"mc-data-manager":        "MC_WEB_CONSOLE_DATA_MANAGER",
+	}
+	for in, want := range cases {
+		if got := frameworkEnvKey(in); got != want {
+			t.Fatalf("frameworkEnvKey(%s) = %s, want %s", in, got, want)
+		}
+	}
+}
+
+// TestValidFrameworkURL 스킴 방어 검증 (토큰 전송 대상 한정)
+func TestValidFrameworkURL(t *testing.T) {
+	valid := []string{"http://a", "https://a"}
+	invalid := []string{"", "ftp://a", "a.example.com", "//a"}
+	for _, u := range valid {
+		if !validFrameworkURL(u) {
+			t.Fatalf("expected valid: %s", u)
+		}
+	}
+	for _, u := range invalid {
+		if validFrameworkURL(u) {
+			t.Fatalf("expected invalid: %s", u)
+		}
+	}
+}

--- a/front/actions/cmd.go
+++ b/front/actions/cmd.go
@@ -29,7 +29,9 @@ type cmdCommonRequest struct {
 
 // PostCmdInfraHandler forwards a remote command request to mc-infra-manager.
 // The JS sends JSON with pathParams/Request; this handler calls mc-infra-manager
-// directly with Basic auth, bypassing the API proxy which lacks this action.
+// directly (bypassing the API proxy) so the raw command payload passes through
+// unchanged. The target BaseURL/auth type come from the API server's getapihosts
+// (api.yaml + registry), so no address is hardcoded here.
 func PostCmdInfraHandler(c echo.Context) error {
 	var req cmdCommonRequest
 	if err := json.NewDecoder(c.Request().Body).Decode(&req); err != nil {
@@ -42,8 +44,12 @@ func PostCmdInfraHandler(c echo.Context) error {
 		return respondCmdError(c, http.StatusBadRequest, "nsId and infraId are required")
 	}
 
-	// Build mc-infra-manager URL
-	targetURL := fmt.Sprintf("%s/ns/%s/cmd/infra/%s", INFRA_MANAGER_URL, nsId, mciId)
+	// Build mc-infra-manager URL (getapihosts → env → localhost fallback)
+	baseURL, authType := ResolveFramework(c, "mc-infra-manager", "http://localhost:1323/tumblebug")
+	if authType == "" {
+		authType = "basic" // legacy default for mc-infra-manager (cb-tumblebug)
+	}
+	targetURL := fmt.Sprintf("%s/ns/%s/cmd/infra/%s", baseURL, nsId, mciId)
 
 	// Forward optional queryParams (subGroupId, vmId, etc.)
 	if len(req.QueryParams) > 0 {
@@ -65,7 +71,7 @@ func PostCmdInfraHandler(c echo.Context) error {
 		return respondCmdError(c, http.StatusInternalServerError, "failed to build request: "+err.Error())
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.SetBasicAuth(INFRA_MANAGER_USER, INFRA_MANAGER_PASS)
+	applyFrameworkAuth(httpReq, c, "mc-infra-manager", authType)
 
 	client := &http.Client{}
 	resp, err := client.Do(httpReq)

--- a/front/actions/env.go
+++ b/front/actions/env.go
@@ -11,9 +11,6 @@ var API_SCHEME string
 var API_ADDR string
 var API_PORT string
 var SESSION_SECRET string
-var INFRA_MANAGER_URL string
-var INFRA_MANAGER_USER string
-var INFRA_MANAGER_PASS string
 
 func init() {
 	// Get environment variables with defaults
@@ -23,9 +20,8 @@ func init() {
 	API_ADDR = getEnvOrDefault("MC_WEB_CONSOLE_API_ADDR", "localhost")
 	API_PORT = getEnvOrDefault("MC_WEB_CONSOLE_API_PORT", "3000")
 	SESSION_SECRET = getEnvOrDefault("MC_WEB_CONSOLE_SESSION_SECRET", "mc-web-console-secret-key")
-	INFRA_MANAGER_URL = getEnvOrDefault("MC_WEB_CONSOLE_INFRA_MANAGER_URL", "http://localhost:1323/tumblebug")
-	INFRA_MANAGER_USER = getEnvOrDefault("MC_WEB_CONSOLE_INFRA_MANAGER_USER", "default")
-	INFRA_MANAGER_PASS = getEnvOrDefault("MC_WEB_CONSOLE_INFRA_MANAGER_PASS", "default")
+	// mc-infra-manager 접속 정보는 apihosts.go의 ResolveFramework/applyFrameworkAuth가
+	// getapihosts(+MC_WEB_CONSOLE_INFRA_MANAGER_URL/_USER/_PASS env 폴백)로 해석한다.
 }
 
 func getEnvOrDefault(key, defaultValue string) string {

--- a/front/actions/upload.go
+++ b/front/actions/upload.go
@@ -92,8 +92,12 @@ func PostFileToInfraHandler(c echo.Context) error {
 	}
 	writer.Close()
 
-	// Build target URL with path substitution
-	targetURL := fmt.Sprintf("%s/ns/%s/transferFile/infra/%s", INFRA_MANAGER_URL, nsId, infraId)
+	// Build target URL with path substitution (getapihosts → env → localhost fallback)
+	baseURL, authType := ResolveFramework(c, "mc-infra-manager", "http://localhost:1323/tumblebug")
+	if authType == "" {
+		authType = "basic" // legacy default for mc-infra-manager (cb-tumblebug)
+	}
+	targetURL := fmt.Sprintf("%s/ns/%s/transferFile/infra/%s", baseURL, nsId, infraId)
 
 	// Forward queryParams as URL query string (e.g. subGroupId, vmId)
 	if len(req.QueryParams) > 0 {
@@ -109,9 +113,7 @@ func PostFileToInfraHandler(c echo.Context) error {
 		return respondUploadError(c, http.StatusInternalServerError, "failed to build request: "+err.Error())
 	}
 	httpReq.Header.Set("Content-Type", writer.FormDataContentType())
-
-	// Use Basic auth for mc-infra-manager (cb-tumblebug)
-	httpReq.SetBasicAuth(INFRA_MANAGER_USER, INFRA_MANAGER_PASS)
+	applyFrameworkAuth(httpReq, c, "mc-infra-manager", authType)
 
 	client := &http.Client{}
 	resp, err := client.Do(httpReq)

--- a/front/assets/css/tabler_custom.scss
+++ b/front/assets/css/tabler_custom.scss
@@ -25,3 +25,9 @@
 .card-header {
   padding: 15px;
 }
+// template carry-through read-only 필드 — "(read-only)" 문구 대신 스타일로 잠김 표현
+#carry_through_fields .carry-through-readonly {
+  background-color: var(--tblr-bg-surface-secondary);
+  color: var(--tblr-secondary);
+  cursor: default;
+}

--- a/front/assets/js/common/api/asyncRequestNotify.js
+++ b/front/assets/js/common/api/asyncRequestNotify.js
@@ -213,6 +213,19 @@ function bindActions() {
     });
   }
 
+  const toggleEl = document.getElementById('async-request-notif-toggle');
+  if (toggleEl && !toggleEl.dataset.refreshBound) {
+    toggleEl.dataset.refreshBound = '1';
+    // Interval polling stops while nothing is in flight — refresh once on open
+    // so the list reflects jobs started elsewhere (other tabs/sessions)
+    toggleEl.addEventListener('show.bs.dropdown', () => {
+      const t = tracker();
+      if (t && t.refreshNow) {
+        t.refreshNow();
+      }
+    });
+  }
+
   const menuEl = document.getElementById('async-request-notif-menu');
   if (menuEl && !menuEl.dataset.selectBound) {
     menuEl.dataset.selectBound = '1';

--- a/front/assets/js/common/api/asyncRequestTracker.js
+++ b/front/assets/js/common/api/asyncRequestTracker.js
@@ -225,10 +225,23 @@ async function refreshFromServer() {
         startPolling(job);
       }
     });
+    // Nothing in flight (server list has no Handling job and no active GetRequest
+    // poll — the timers guard covers the gap between track() and the server row
+    // appearing): stop the list interval. track() restarts it on the next request.
+    if (!jobs.some((j) => j.status === 'Handling') && timers.size === 0) {
+      stopListRefresh();
+    }
   } catch (e) {
     if (useServer !== true) {
       useServer = false;
     }
+  }
+}
+
+function stopListRefresh() {
+  if (listTimer) {
+    clearInterval(listTimer);
+    listTimer = null;
   }
 }
 
@@ -237,9 +250,13 @@ function ensureListRefresh() {
     return;
   }
   listTimer = setInterval(function () {
-    if (useServer !== false) {
-      refreshFromServer();
+    if (useServer === false) {
+      // fallback mode has no server list — per-request GetRequest timers
+      // handle progress and stop on their own
+      stopListRefresh();
+      return;
     }
+    refreshFromServer();
   }, LIST_REFRESH_MS);
 }
 
@@ -352,6 +369,14 @@ export function track(opts) {
   startPolling(job);
   ensureListRefresh();
   refreshFromServer();
+}
+
+/**
+ * One-shot server list refresh — used by the navbar dropdown on open so the
+ * list stays current even while interval polling is stopped.
+ */
+export function refreshNow() {
+  return refreshFromServer();
 }
 
 export function resume() {

--- a/front/assets/js/common/api/asyncRequestTracker.js
+++ b/front/assets/js/common/api/asyncRequestTracker.js
@@ -4,10 +4,13 @@
  */
 
 const STORAGE_KEY = 'mcwc_async_requests';
+const TOASTED_KEY = 'mcwc_async_toasted';
 const POLL_MS = 2500;
 const LIST_REFRESH_MS = 2000;
 const MAX_MS = 15 * 60 * 1000;
 const MAX_JOBS = 20;
+const RECENT_FINISH_TOAST_MS = 30 * 1000;
+const TOASTED_MAX = 40;
 const GET_REQUEST_URL = '/api/mc-infra-manager/GetRequest';
 const LIST_URL = '/api/async-requests';
 const EVENT_NAME = 'mcwc-async-request-changed';
@@ -16,7 +19,6 @@ const timers = new Map();
 const listeners = new Set();
 let useServer = null;
 let listTimer = null;
-let lastToastStatus = new Map();
 
 function toastApi() {
   return webconsolejs && webconsolejs['common/utils/toast'];
@@ -138,6 +140,48 @@ function finishToast(job, type, message) {
   }
 }
 
+function loadToasted() {
+  try {
+    const raw = sessionStorage.getItem(TOASTED_KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch (e) {
+    return {};
+  }
+}
+
+function saveToasted(map) {
+  const keys = Object.keys(map);
+  if (keys.length > TOASTED_MAX) {
+    keys.slice(0, keys.length - TOASTED_MAX).forEach((k) => delete map[k]);
+  }
+  try {
+    sessionStorage.setItem(TOASTED_KEY, JSON.stringify(map));
+  } catch (e) {
+    /* storage full — dedupe degrades gracefully */
+  }
+}
+
+/**
+ * Terminal-status toast, at most once per requestId per tab session
+ * (ledger in sessionStorage so page reloads stay silent).
+ * Shows only when the transition was observed live on this page, or the job
+ * finished within RECENT_FINISH_TOAST_MS (completion during navigation).
+ */
+function maybeFinishToast(job, status, live, message) {
+  const toasted = loadToasted();
+  if (toasted[job.requestId] === status) {
+    return;
+  }
+  const recent =
+    job.finishedAt && Date.now() - job.finishedAt < RECENT_FINISH_TOAST_MS;
+  if (live || recent) {
+    finishToast(job, status === 'Success' ? 'success' : 'error', message);
+  }
+  toasted[job.requestId] = status;
+  saveToasted(toasted);
+}
+
 function markFinishedLocal(requestId, status, message) {
   stopTimer(requestId);
   const jobs = loadJobsLocal();
@@ -158,25 +202,22 @@ function markFinishedLocal(requestId, status, message) {
 function maybeToastTransition(prevJobs, nextJobs) {
   const prevMap = new Map((prevJobs || []).map((j) => [j.requestId, j]));
   (nextJobs || []).forEach((job) => {
-    const prev = prevMap.get(job.requestId);
-    const prevStatus = prev ? prev.status : lastToastStatus.get(job.requestId);
-    if (prevStatus === job.status) {
-      return;
-    }
-    lastToastStatus.set(job.requestId, job.status);
     if (job.status === 'Handling') {
-      showProgress(job);
+      // progress toast is shown only at track() time — never on load/refresh
       return;
     }
+    const prev = prevMap.get(job.requestId);
+    const live = !!prev && prev.status === 'Handling';
     if (job.status === 'Success') {
-      finishToast(job, 'success', job.label + ' — completed');
+      maybeFinishToast(job, 'Success', live, job.label + ' — completed');
       stopTimer(job.requestId);
       return;
     }
     if (job.status === 'Error' || job.status === 'Timeout') {
-      finishToast(
+      maybeFinishToast(
         job,
-        'error',
+        job.status,
+        live,
         job.message || job.label + ' — ' + (job.status === 'Timeout' ? 'timed out' : 'failed')
       );
       stopTimer(job.requestId);
@@ -278,9 +319,8 @@ async function pollOnce(job) {
 
     if (status === 'Success' || status === 'success') {
       const msg = job.label + ' — completed';
-      finishToast(job, 'success', msg);
+      maybeFinishToast(job, 'Success', true, msg);
       if (useServer) {
-        lastToastStatus.set(job.requestId, 'Success');
         stopTimer(job.requestId);
         refreshFromServer();
       } else {
@@ -291,9 +331,8 @@ async function pollOnce(job) {
     if (status === 'Error' || status === 'error') {
       const errMsg = details.errorResponse || details.ErrorResponse || 'failed';
       const msg = job.label + ' — ' + errMsg;
-      finishToast(job, 'error', msg);
+      maybeFinishToast(job, 'Error', true, msg);
       if (useServer) {
-        lastToastStatus.set(job.requestId, 'Error');
         stopTimer(job.requestId);
         refreshFromServer();
       } else {
@@ -323,7 +362,7 @@ function startPolling(job) {
     }
     if (Date.now() - current.startedAt > MAX_MS) {
       const msg = current.label + ' — status check timed out';
-      finishToast(current, 'error', msg);
+      maybeFinishToast(current, 'Timeout', true, msg);
       if (!useServer) {
         markFinishedLocal(current.requestId, 'Timeout', msg);
       }
@@ -356,7 +395,6 @@ export function track(opts) {
     status: 'Handling',
     href: opts.href || '',
   };
-  lastToastStatus.set(requestId, 'Handling');
   showProgress(job);
   if (useServer !== true) {
     upsertJobLocal(job);
@@ -387,7 +425,7 @@ export function resume() {
     }
     const jobs = loadJobsLocal();
     jobs.filter((j) => j.status === 'Handling').forEach((job) => {
-      showProgress(job);
+      // no progress re-toast on load — badge/list carry in-flight state
       startPolling(job);
     });
     emit(jobs);

--- a/front/assets/js/common/api/services/company_api.js
+++ b/front/assets/js/common/api/services/company_api.js
@@ -1,0 +1,72 @@
+// Company(플랫폼 싱글톤) API 서비스 — mc-iam-manager /api/company
+
+function unwrapResponse(response) {
+  if (!response) {
+    throw new Error('Invalid response from server');
+  }
+  // commonAPIPost는 404/403 등에서 axios error 객체를 그대로 반환
+  if (response.response) {
+    const status = response.response.status;
+    const body = response.response.data || {};
+    const msg = (body.status && body.status.message)
+      || body.message
+      || body.error
+      || (body.responseData && body.responseData.error)
+      || response.message
+      || 'Request failed';
+    const err = new Error(msg);
+    err.status = status;
+    err.response = response.response;
+    throw err;
+  }
+  if (response.status === 204) {
+    return null;
+  }
+  if (!response.data) {
+    throw new Error('Invalid response from server');
+  }
+  if (response.status >= 400) {
+    const msg = (response.data.status && response.data.status.message)
+      || response.data.message
+      || response.data.error
+      || (response.data.responseData && response.data.responseData.error)
+      || 'Request failed';
+    const err = new Error(msg);
+    err.status = response.status;
+    err.response = response;
+    throw err;
+  }
+  return response.data.responseData;
+}
+
+export async function getCompany() {
+  const controller = '/api/mc-iam-manager/getCompany';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller);
+  return unwrapResponse(response);
+}
+
+export async function createCompany(companyData) {
+  const controller = '/api/mc-iam-manager/createCompany';
+  const data = { request: companyData };
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, data);
+  return unwrapResponse(response);
+}
+
+export async function updateCompany(companyData) {
+  const controller = '/api/mc-iam-manager/updateCompany';
+  const data = { request: companyData };
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, data);
+  return unwrapResponse(response);
+}
+
+export async function deactivateCompany() {
+  const controller = '/api/mc-iam-manager/deactivateCompany';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller);
+  return unwrapResponse(response);
+}
+
+export async function activateCompany() {
+  const controller = '/api/mc-iam-manager/activateCompany';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller);
+  return unwrapResponse(response);
+}

--- a/front/assets/js/common/api/services/mci_api.js
+++ b/front/assets/js/common/api/services/mci_api.js
@@ -254,8 +254,11 @@ export async function mciDynamicReview(mciName, mciDesc, Express_Server_Config_A
     description: config.description,
     rootDiskSize: (config.rootDiskSize !== "" && config.rootDiskSize !== undefined) ? parseInt(config.rootDiskSize) : 0,
     rootDiskType: config.rootDiskType,
-    label: config.label || {},
-    vmUserPassword: config.vmUserPassword || ""
+    ...(config.zone ? { zone: config.zone } : {}),
+    ...(config.nodeUserPassword ? { nodeUserPassword: config.nodeUserPassword } : {}),
+    ...(config.label && Object.keys(config.label).length > 0 ? { label: config.label } : {}),
+    ...(config.vNetTemplateId ? { vNetTemplateId: config.vNetTemplateId } : {}),
+    ...(config.sgTemplateId ? { sgTemplateId: config.sgTemplateId } : {})
   }));
 
   // command 처리 - 첫 번째 서버의 command를 사용 (모든 서버가 동일한 command를 사용한다고 가정)
@@ -302,7 +305,12 @@ export async function mciDynamic(mciName, mciDesc, Express_Server_Config_Arr, ns
     connectionName: config.connectionName,
     description: config.description,
     rootDiskSize: (config.rootDiskSize !== "" && config.rootDiskSize !== undefined) ? parseInt(config.rootDiskSize) : 0,
-    rootDiskType: config.rootDiskType
+    rootDiskType: config.rootDiskType,
+    ...(config.zone ? { zone: config.zone } : {}),
+    ...(config.nodeUserPassword ? { nodeUserPassword: config.nodeUserPassword } : {}),
+    ...(config.label && Object.keys(config.label).length > 0 ? { label: config.label } : {}),
+    ...(config.vNetTemplateId ? { vNetTemplateId: config.vNetTemplateId } : {}),
+    ...(config.sgTemplateId ? { sgTemplateId: config.sgTemplateId } : {})
   }));
 
   // command 처리 - 첫 번째 서버의 command를 사용 (모든 서버가 동일한 command를 사용한다고 가정)

--- a/front/assets/js/common/api/services/mci_api.js
+++ b/front/assets/js/common/api/services/mci_api.js
@@ -355,40 +355,46 @@ export async function mciDynamic(mciName, mciDesc, Express_Server_Config_Arr, ns
 
 export async function vmDynamic(mciId, nsId, Express_Server_Config_Arr) {
 
-  var obj = {}
-  obj = Express_Server_Config_Arr[0]
-  const data = {
-    pathParams: {
-      nsId: nsId,
-      infraId: mciId,
-    },
-    request: {
-      "imageId": obj.commonImage,
-      "specId": obj.commonSpec,
-      "connectionName": obj.connectionName,
-      "description": obj.description,
-      // "label": "",
-      "name": obj.name,
-      "nodeGroupSize": parseInt(obj.subGroupSize) || 1,
-      "rootDiskSize": (obj.rootDiskSize !== "" && obj.rootDiskSize !== undefined) ? parseInt(obj.rootDiskSize) : 0,
-      "rootDiskType": obj.rootDiskType,
-    }
-  }
-
-
+  // 서버 body가 단일 CreateNodeGroupDynamicReq이므로 nodeGroup별로 순차 호출
   var controller = "/api/" + "mc-infra-manager/" + "PostInfraNodeGroupDynamic";
-  const ngName = (obj && obj.name) ? obj.name : 'nodegroup';
-  const tracked = webconsolejs['common/api/requestId'].beginTrackedRequest(
-    'PostInfraNodeGroupDynamic',
-    'NodeGroup add: ' + ngName
-  );
-  const response = await webconsolejs["common/api/http"].commonAPIPost(
-    controller,
-    data,
-    false,
-    tracked.httpOptions
-  );
-  return response;
+  const responses = [];
+  for (const obj of Express_Server_Config_Arr) {
+    const data = {
+      pathParams: {
+        nsId: nsId,
+        infraId: mciId,
+      },
+      request: {
+        "imageId": obj.commonImage,
+        "specId": obj.commonSpec,
+        "connectionName": obj.connectionName,
+        "description": obj.description,
+        "name": obj.name,
+        "nodeGroupSize": parseInt(obj.subGroupSize) || 1,
+        "rootDiskSize": (obj.rootDiskSize !== "" && obj.rootDiskSize !== undefined) ? parseInt(obj.rootDiskSize) : 0,
+        "rootDiskType": obj.rootDiskType,
+        ...(obj.zone ? { zone: obj.zone } : {}),
+        ...(obj.nodeUserPassword ? { nodeUserPassword: obj.nodeUserPassword } : {}),
+        ...(obj.label && Object.keys(obj.label).length > 0 ? { label: obj.label } : {}),
+        ...(obj.vNetTemplateId ? { vNetTemplateId: obj.vNetTemplateId } : {}),
+        ...(obj.sgTemplateId ? { sgTemplateId: obj.sgTemplateId } : {})
+      }
+    }
+
+    const ngName = (obj && obj.name) ? obj.name : 'nodegroup';
+    const tracked = webconsolejs['common/api/requestId'].beginTrackedRequest(
+      'PostInfraNodeGroupDynamic',
+      'NodeGroup add: ' + ngName
+    );
+    const response = await webconsolejs["common/api/http"].commonAPIPost(
+      controller,
+      data,
+      false,
+      tracked.httpOptions
+    );
+    responses.push(response);
+  }
+  return responses;
 }
 
 export async function mciRecommendVm(data) {

--- a/front/assets/js/common/api/services/workspace_api.js
+++ b/front/assets/js/common/api/services/workspace_api.js
@@ -99,7 +99,7 @@ export async function getProjectListByWorkspaceId(workspaceId) {
     }
   }
   let projectList = [];
-  const response = await webconsolejs["common/api/http"].commonAPIPost('/api/mc-iam-manager/getProjectsByWorkspaceId', requestObject)
+  const response = await webconsolejs["common/api/http"].commonAPIPost('/api/mc-iam-manager/listUserProjectsByWorkspace', requestObject)
   let data = response.data.responseData.projects
   console.debug("GetWPmappingListByWorkspaceId data :", data)
   data.forEach(item => {

--- a/front/assets/js/pages/settings/accountnaccess/organizations/companyinfo.js
+++ b/front/assets/js/pages/settings/accountnaccess/organizations/companyinfo.js
@@ -1,76 +1,196 @@
-if (typeof webconsolejs === 'undefined') window.webconsolejs = {};
+if (typeof webconsolejs === 'undefined') {
+  window.webconsolejs = {};
+}
 if (typeof webconsolejs['pages/settings/accountnaccess/organizations/companyinfo'] === 'undefined') {
-    webconsolejs['pages/settings/accountnaccess/organizations/companyinfo'] = {};
+  webconsolejs['pages/settings/accountnaccess/organizations/companyinfo'] = {};
 }
 
 const AppState = {
-    org: null
+  company: null
 };
 
-const groupsApi = () => webconsolejs['common/api/services/groups_api'];
+const companyApi = () => webconsolejs['common/api/services/company_api'];
+
+function formatDate(value) {
+  if (!value) {
+    return '-';
+  }
+  try {
+    return new Date(value).toLocaleString();
+  } catch (e) {
+    return String(value);
+  }
+}
+
+function setVisible(id, visible) {
+  const el = document.getElementById(id);
+  if (!el) {
+    return;
+  }
+  el.classList.toggle('d-none', !visible);
+  if (visible) {
+    el.style.display = '';
+  }
+}
 
 const companyInfoPage = {
-    async load() {
-        try {
-            const list = await groupsApi().getGroupList();
-            const orgs = Array.isArray(list) ? list : [];
-            if (orgs.length === 0) throw new Error('No organization found');
-            // 최상위 조직: level이 가장 낮은 항목
-            const root = orgs.reduce((min, o) => (o.level < min.level ? o : min), orgs[0]);
-            AppState.org = root;
-            this._render(root);
-        } catch (e) {
-            console.error('Failed to load organization info:', e);
-            document.getElementById('companyinfo-loading').innerHTML =
-                '<div class="alert alert-danger">Failed to load organization info.</div>';
-        }
-    },
+  async load() {
+    document.getElementById('companyinfo-loading').style.display = '';
+    document.getElementById('companyinfo-data').style.display = 'none';
+    document.getElementById('companyinfo-empty').style.display = 'none';
+    setVisible('companyinfo-edit-btn', false);
+    setVisible('companyinfo-create-btn', false);
+    setVisible('companyinfo-activate-btn', false);
 
-    _render(org) {
-        document.getElementById('ci-name').textContent = org.name || '-';
-        document.getElementById('ci-code').textContent = org.organizationCode || org.code || '-';
-        document.getElementById('ci-level').textContent = org.level ?? '-';
-        document.getElementById('ci-path').textContent = org.path || '-';
-        document.getElementById('ci-description').textContent = org.description || '-';
-        document.getElementById('ci-user-count').textContent = org.userCount ?? '-';
-        document.getElementById('companyinfo-loading').style.display = 'none';
-        document.getElementById('companyinfo-data').style.display = '';
-    },
-
-    enterEditMode() {
-        if (!AppState.org) return;
-        document.getElementById('ci-edit-name').value = AppState.org.name || '';
-        document.getElementById('ci-edit-description').value = AppState.org.description || '';
-        document.getElementById('companyinfo-view-card').style.display = 'none';
-        document.getElementById('companyinfo-edit-card').style.display = '';
-    },
-
-    cancelEdit() {
-        document.getElementById('companyinfo-edit-card').style.display = 'none';
-        document.getElementById('companyinfo-view-card').style.display = '';
-    },
-
-    async saveEdit() {
-        const name = document.getElementById('ci-edit-name').value.trim();
-        if (!name) {
-            alert('Name is required.');
-            return;
-        }
-        const description = document.getElementById('ci-edit-description').value.trim();
-        try {
-            const updated = await groupsApi().updateGroup(AppState.org.id, { name, description });
-            AppState.org = { ...AppState.org, name, description, ...updated };
-            this._render(AppState.org);
-            this.cancelEdit();
-        } catch (e) {
-            console.error('Failed to update organization:', e);
-            alert('Failed to save. Please try again.');
-        }
+    try {
+      const company = await companyApi().getCompany();
+      AppState.company = company;
+      this._render(company);
+    } catch (e) {
+      console.error('Failed to load company info:', e);
+      AppState.company = null;
+      document.getElementById('companyinfo-loading').style.display = 'none';
+      if (e.status === 404) {
+        document.getElementById('companyinfo-empty').style.display = '';
+        setVisible('companyinfo-create-btn', true);
+        return;
+      }
+      document.getElementById('companyinfo-loading').innerHTML =
+        '<div class="alert alert-danger">Failed to load company info.</div>';
     }
+  },
+
+  _render(company) {
+    document.getElementById('ci-name').textContent = company.name || '-';
+    document.getElementById('ci-description').textContent = company.description || '-';
+    document.getElementById('ci-realm').textContent = company.realm_name || '-';
+    document.getElementById('ci-client-id').textContent = company.kc_client_id || '-';
+    document.getElementById('ci-status').textContent = company.status || '-';
+    document.getElementById('ci-created-at').textContent = formatDate(company.created_at);
+    document.getElementById('ci-updated-at').textContent = formatDate(company.updated_at);
+
+    document.getElementById('companyinfo-loading').style.display = 'none';
+    document.getElementById('companyinfo-empty').style.display = 'none';
+    document.getElementById('companyinfo-data').style.display = '';
+    setVisible('companyinfo-edit-btn', true);
+
+    // Deactivate는 UI에서 숨김. inactive일 때만 Activate 노출.
+    const isActive = (company.status || '').toLowerCase() === 'active';
+    setVisible('companyinfo-activate-btn', !isActive);
+  },
+
+  enterEditMode() {
+    if (!AppState.company) {
+      return;
+    }
+    document.getElementById('ci-edit-name').value = AppState.company.name || '';
+    document.getElementById('ci-edit-description').value = AppState.company.description || '';
+    document.getElementById('ci-edit-realm').value = AppState.company.realm_name || '';
+    document.getElementById('ci-edit-client-id').value = AppState.company.kc_client_id || '';
+    document.getElementById('companyinfo-view-card').style.display = 'none';
+    document.getElementById('companyinfo-create-card').style.display = 'none';
+    document.getElementById('companyinfo-edit-card').style.display = '';
+  },
+
+  cancelEdit() {
+    document.getElementById('companyinfo-edit-card').style.display = 'none';
+    document.getElementById('companyinfo-view-card').style.display = '';
+  },
+
+  async saveEdit() {
+    const name = document.getElementById('ci-edit-name').value.trim();
+    if (!name) {
+      alert('Name is required.');
+      return;
+    }
+    const description = document.getElementById('ci-edit-description').value.trim();
+    try {
+      const updated = await companyApi().updateCompany({ name, description });
+      AppState.company = { ...AppState.company, ...updated };
+      this._render(AppState.company);
+      this.cancelEdit();
+    } catch (e) {
+      console.error('Failed to update company:', e);
+      alert(e.message || 'Failed to save. Please try again.');
+    }
+  },
+
+  enterCreateMode() {
+    document.getElementById('ci-create-name').value = '';
+    document.getElementById('ci-create-realm').value = '';
+    document.getElementById('ci-create-client-id').value = '';
+    document.getElementById('ci-create-client-secret').value = '';
+    document.getElementById('ci-create-description').value = '';
+    document.getElementById('companyinfo-view-card').style.display = 'none';
+    document.getElementById('companyinfo-edit-card').style.display = 'none';
+    document.getElementById('companyinfo-create-card').style.display = '';
+  },
+
+  cancelCreate() {
+    document.getElementById('companyinfo-create-card').style.display = 'none';
+    document.getElementById('companyinfo-view-card').style.display = '';
+  },
+
+  async saveCreate() {
+    const name = document.getElementById('ci-create-name').value.trim();
+    const realmName = document.getElementById('ci-create-realm').value.trim();
+    const kcClientId = document.getElementById('ci-create-client-id').value.trim();
+    const kcClientSecret = document.getElementById('ci-create-client-secret').value.trim();
+    const description = document.getElementById('ci-create-description').value.trim();
+
+    if (!name || !realmName || !kcClientId || !kcClientSecret) {
+      alert('Name, Realm Name, Client ID, and Client Secret are required.');
+      return;
+    }
+
+    try {
+      const created = await companyApi().createCompany({
+        name,
+        realm_name: realmName,
+        kc_client_id: kcClientId,
+        kc_client_secret: kcClientSecret,
+        description
+      });
+      AppState.company = created;
+      this._render(created);
+      this.cancelCreate();
+    } catch (e) {
+      console.error('Failed to create company:', e);
+      alert(e.message || 'Failed to create. Please try again.');
+    }
+  },
+
+  async activate() {
+    if (!confirm('Activate this company?')) {
+      return;
+    }
+    try {
+      const updated = await companyApi().activateCompany();
+      AppState.company = { ...AppState.company, ...updated };
+      this._render(AppState.company);
+    } catch (e) {
+      console.error('Failed to activate company:', e);
+      alert(e.message || 'Failed to activate.');
+    }
+  },
+
+  async deactivate() {
+    if (!confirm('Deactivate this company?')) {
+      return;
+    }
+    try {
+      const updated = await companyApi().deactivateCompany();
+      AppState.company = { ...AppState.company, ...updated };
+      this._render(AppState.company);
+    } catch (e) {
+      console.error('Failed to deactivate company:', e);
+      alert(e.message || 'Failed to deactivate.');
+    }
+  }
 };
 
 window.companyInfoPage = companyInfoPage;
 
 document.addEventListener('DOMContentLoaded', () => {
-    companyInfoPage.load();
+  companyInfoPage.load();
 });

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -331,7 +331,7 @@ export async function displayNewServerForm() {
     // 모달들 초기화
     resetModals();
 
-    // 신규 모드 — 직전 편집(template li)의 carry-through 섹션 잔상 제거
+    // 신규 모드 — 직전 편집(template li)의 carry-through 값 잔상 제거 (빈 필드로 초기화)
     renderCarryThroughSection(null);
 
     var div = document.getElementById("server_configuration");
@@ -618,7 +618,7 @@ export function view_express(cnt) {
   $("#p_subGroupSize").val(select_form_data.subGroupSize || "1");
   $("#p_vm_cnt").val(select_form_data.subGroupSize || "1");
   
-  // template carry-through 필드 read-only 표시 (값이 있는 필드만)
+  // template carry-through 필드 read-only 표시 (5필드 항상, 값 없으면 빈 칸)
   renderCarryThroughSection(select_form_data);
 
   // 서버 입력 폼 표시
@@ -629,27 +629,25 @@ export function view_express(cnt) {
 }
 
 // template Add NodeGroup carry-through 필드(zone/nodeUserPassword/label/vNetTemplateId/sgTemplateId)를
-// 편집 폼에 read-only로 표시 — 값이 있는 필드만 렌더, 전부 없으면(수동 입력 SubGroup) 섹션 숨김.
-// nodeUserPassword는 존재 여부만 마스킹 표시하고 평문을 노출하지 않는다.
+// 편집 폼에 read-only로 표시 — 5필드 모두 항상 렌더, 값이 없으면 빈 입력으로 표시.
+// nodeUserPassword는 값이 있을 때만 마스킹 표시하고 평문을 노출하지 않는다.
 function renderCarryThroughSection(data) {
   var section = document.getElementById("carry_through_section");
   var fields = document.getElementById("carry_through_fields");
   if (!section || !fields) return;
 
-  var items = [];
-  if (data && data.zone) items.push(["zone", "Zone", data.zone]);
-  if (data && data.nodeUserPassword) items.push(["nodeUserPassword", "Node User Password", "••••••"]);
-  if (data && data.label && Object.keys(data.label).length > 0) {
-    items.push(["label", "Label", Object.keys(data.label).map(function (k) { return k + "=" + data.label[k]; }).join(", ")]);
-  }
-  if (data && data.vNetTemplateId) items.push(["vNetTemplateId", "vNet Template ID", data.vNetTemplateId]);
-  if (data && data.sgTemplateId) items.push(["sgTemplateId", "SG Template ID", data.sgTemplateId]);
+  var items = [
+    ["zone", "Zone", (data && data.zone) || ""],
+    ["nodeUserPassword", "Node User Password", data && data.nodeUserPassword ? "••••••" : ""],
+    ["label", "Label",
+      data && data.label && Object.keys(data.label).length > 0
+        ? Object.keys(data.label).map(function (k) { return k + "=" + data.label[k]; }).join(", ")
+        : ""],
+    ["vNetTemplateId", "vNet Template ID", (data && data.vNetTemplateId) || ""],
+    ["sgTemplateId", "SG Template ID", (data && data.sgTemplateId) || ""],
+  ];
 
   fields.innerHTML = "";
-  if (items.length === 0) {
-    section.classList.add("d-none");
-    return;
-  }
   items.forEach(function (item) {
     var col = document.createElement("div");
     col.className = "col-md-6";
@@ -658,7 +656,7 @@ function renderCarryThroughSection(data) {
     label.textContent = item[1];
     var input = document.createElement("input");
     input.type = "text";
-    input.className = "form-control";
+    input.className = "form-control carry-through-readonly";
     input.readOnly = true;
     input.setAttribute("data-carry-field", item[0]);
     input.value = item[2]; // DOM value 할당 — template 값의 HTML 해석(XSS) 방지

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -329,7 +329,10 @@ export async function displayNewServerForm() {
     
     // 모달들 초기화
     resetModals();
-    
+
+    // 신규 모드 — 직전 편집(template li)의 carry-through 섹션 잔상 제거
+    renderCarryThroughSection(null);
+
     var div = document.getElementById("server_configuration");
     webconsolejs["partials/layout/navigatePages"].toggleSubElement(div)
 
@@ -614,11 +617,55 @@ export function view_express(cnt) {
   $("#p_subGroupSize").val(select_form_data.subGroupSize || "1");
   $("#p_vm_cnt").val(select_form_data.subGroupSize || "1");
   
+  // template carry-through 필드 read-only 표시 (값이 있는 필드만)
+  renderCarryThroughSection(select_form_data);
+
   // 서버 입력 폼 표시
   var div = document.getElementById("server_configuration");
   if (!div.classList.contains("active")) {
     webconsolejs["partials/layout/navigatePages"].toggleSubElement(div);
   }
+}
+
+// template Add NodeGroup carry-through 필드(zone/nodeUserPassword/label/vNetTemplateId/sgTemplateId)를
+// 편집 폼에 read-only로 표시 — 값이 있는 필드만 렌더, 전부 없으면(수동 입력 SubGroup) 섹션 숨김.
+// nodeUserPassword는 존재 여부만 마스킹 표시하고 평문을 노출하지 않는다.
+function renderCarryThroughSection(data) {
+  var section = document.getElementById("carry_through_section");
+  var fields = document.getElementById("carry_through_fields");
+  if (!section || !fields) return;
+
+  var items = [];
+  if (data && data.zone) items.push(["zone", "Zone", data.zone]);
+  if (data && data.nodeUserPassword) items.push(["nodeUserPassword", "Node User Password", "••••••"]);
+  if (data && data.label && Object.keys(data.label).length > 0) {
+    items.push(["label", "Label", Object.keys(data.label).map(function (k) { return k + "=" + data.label[k]; }).join(", ")]);
+  }
+  if (data && data.vNetTemplateId) items.push(["vNetTemplateId", "vNet Template ID", data.vNetTemplateId]);
+  if (data && data.sgTemplateId) items.push(["sgTemplateId", "SG Template ID", data.sgTemplateId]);
+
+  fields.innerHTML = "";
+  if (items.length === 0) {
+    section.classList.add("d-none");
+    return;
+  }
+  items.forEach(function (item) {
+    var col = document.createElement("div");
+    col.className = "col-md-6";
+    var label = document.createElement("label");
+    label.className = "form-label";
+    label.textContent = item[1];
+    var input = document.createElement("input");
+    input.type = "text";
+    input.className = "form-control";
+    input.readOnly = true;
+    input.setAttribute("data-carry-field", item[0]);
+    input.value = item[2]; // DOM value 할당 — template 값의 HTML 해석(XSS) 방지
+    col.appendChild(label);
+    col.appendChild(input);
+    fields.appendChild(col);
+  });
+  section.classList.remove("d-none");
 }
 
 

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -501,8 +501,8 @@ function addServerConfigToList(express_form) {
 
   // 수정 모드인지 신규 추가 모드인지 판단
   if (currentEditingIndex >= 0 && currentEditingIndex < Express_Server_Config_Arr.length) {
-    // 수정 모드: 기존 데이터를 업데이트
-    Express_Server_Config_Arr[currentEditingIndex] = express_form;
+    // 수정 모드: 기존 데이터를 업데이트 (폼에 없는 carry-through 필드는 보존)
+    Express_Server_Config_Arr[currentEditingIndex] = { ...Express_Server_Config_Arr[currentEditingIndex], ...express_form };
 
     // 리스트 아이템 텍스트 업데이트
     var vmEleId = "vm";

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -314,7 +314,8 @@ export async function displayNewServerForm() {
   // +SubGroup 버튼 클릭 시 수정 모드 플래그 초기화 (신규 추가 모드)
   currentEditingIndex = -1;
   
-  var deploymentAlgo = $("#mci_deploy_algorithm").val();
+  // 화면별 select 참조 — Create MCI는 #mci_deploy_algorithm, Extend VM은 #vm_deploy_algorithm
+  var deploymentAlgo = $(isVm ? "#vm_deploy_algorithm" : "#mci_deploy_algorithm").val();
 
   if (deploymentAlgo == "express") {
     // 폼을 열기 전에 추가 초기화
@@ -905,9 +906,7 @@ export async function createVmDynamic() {
     var selectedNsId = selectedWorkspaceProject.nsId;
     var mciId = window.currentMciId;
 
-    webconsolejs["common/api/services/mci_api"].vmDynamic(mciId, selectedNsId, Express_Server_Config_Arr)
-
-    // response가 있으면 
+    await webconsolejs["common/api/services/mci_api"].vmDynamic(mciId, selectedNsId, Express_Server_Config_Arr)
 
     alert("VM creation request completed")
     window.location = `/webconsole/operations/manage/workloads/mciworkloads`;
@@ -1172,13 +1171,15 @@ export function clearExpressForm() {
 // ─── Infra Template으로 MCI 배포 ─────────────────────────────────────────
 
 let templateSelectTable = null;
-let mciDeployAlgorithmPrev = "express";
+// Create MCI(#mci_deploy_algorithm)와 Extend VM(#vm_deploy_algorithm) 두 select가 template 모달을 공유한다
+let deployAlgorithmPrev = { mci_deploy_algorithm: "express", vm_deploy_algorithm: "express" };
+let templateModalSourceSelectId = "mci_deploy_algorithm"; // 모달을 연 select — 닫힐 때 이 select만 되돌린다
 let templateDeploySucceeded = false;
 let templateDeployInFlight = false;
 
 function revertDeployAlgorithmSelect() {
-	const sel = document.getElementById("mci_deploy_algorithm");
-	if (sel && sel.value === "template") sel.value = mciDeployAlgorithmPrev;
+	const sel = document.getElementById(templateModalSourceSelectId);
+	if (sel && sel.value === "template") sel.value = deployAlgorithmPrev[templateModalSourceSelectId] || "express";
 }
 
 // 템플릿 미리보기 초기화 (선택 없음 → 안내문구 표시)
@@ -1235,22 +1236,28 @@ function renderTemplateSelectDetail(template) {
 }
 
 function initTemplateDeploySelect() {
-	const sel = document.getElementById("mci_deploy_algorithm");
-	if (!sel) return;
-	mciDeployAlgorithmPrev = sel.value;
-	sel.addEventListener("change", async function () {
-		if (this.value !== "template") {
-			mciDeployAlgorithmPrev = this.value;
-			return;
-		}
-		const mciName = ($("#mci_name").val() || "").trim();
-		if (!mciName) {
-			webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR, "Please input MCI Name first");
-			this.value = "express";
-			mciDeployAlgorithmPrev = "express";
-			return;
-		}
-		await openTemplateSelectModal();
+	["mci_deploy_algorithm", "vm_deploy_algorithm"].forEach(function (selId) {
+		const sel = document.getElementById(selId);
+		if (!sel) return;
+		deployAlgorithmPrev[selId] = sel.value;
+		sel.addEventListener("change", async function () {
+			if (this.value !== "template") {
+				deployAlgorithmPrev[selId] = this.value;
+				return;
+			}
+			// Create MCI 경로만 MCI Name 선입력 필수 — Extend VM은 기존 MCI 대상이라 불필요
+			if (selId === "mci_deploy_algorithm") {
+				const mciName = ($("#mci_name").val() || "").trim();
+				if (!mciName) {
+					webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR, "Please input MCI Name first");
+					this.value = "express";
+					deployAlgorithmPrev[selId] = "express";
+					return;
+				}
+			}
+			templateModalSourceSelectId = selId;
+			await openTemplateSelectModal();
+		});
 	});
 }
 
@@ -1312,6 +1319,9 @@ export async function openTemplateSelectModal() {
 	modalEl.addEventListener("hidden.bs.modal", function () {
 		if (!templateDeploySucceeded) revertDeployAlgorithmSelect();
 	}, { once: true });
+	// Extend VM 경로에서는 새 MCI를 배포하는 [Deploy from Template] 버튼을 숨긴다 (Add NodeGroup만)
+	const deployFromTplBtn = document.getElementById("btn-deploy-from-template");
+	if (deployFromTplBtn) deployFromTplBtn.classList.toggle("d-none", templateModalSourceSelectId === "vm_deploy_algorithm");
 	resetTemplateSelectDetail();
 	new bootstrap.Modal(modalEl).show();
 }
@@ -1413,7 +1423,8 @@ export function addTemplateToForm() {
 		postCommandUserName: req.postCommand?.userName || "",
 		postCommandTimeoutMinutes: req.postCommand?.timeoutMinutes
 	};
-	if (!$("#mci_desc").val() && templatePrefillInfraState.description) {
+	// Create MCI 경로에서만 — Extend VM은 기존 MCI의 description을 유지한다
+	if (!isVm && !$("#mci_desc").val() && templatePrefillInfraState.description) {
 		$("#mci_desc").val(templatePrefillInfraState.description);
 	}
 

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -460,48 +460,9 @@ export function expressDone_btn() {
   express_form["imageId"] = $("#p_imageId").val(); // imageId 추가
   express_form["specId"] = $("#p_specId").val(); // specId 추가
   express_form["command"] = $("#p_command").val();
-  
-  var server_name = express_form.name;
-  var server_cnt = parseInt(express_form.subGroupSize);
 
-  // 수정 모드인지 신규 추가 모드인지 판단
-  if (currentEditingIndex >= 0 && currentEditingIndex < Express_Server_Config_Arr.length) {
-    // 수정 모드: 기존 데이터를 업데이트
-    Express_Server_Config_Arr[currentEditingIndex] = express_form;
-    
-    // 리스트 아이템 텍스트 업데이트
-    var vmEleId = "vm";
-    if (!isVm) {
-      vmEleId = "mci";
-    }
-    var displayServerCnt = '(' + server_cnt + ')';
-    var listItem = $("#" + vmEleId + "_server_list li").eq(currentEditingIndex + 1); // +1은 plusIcon 때문
-    listItem.text(server_name + displayServerCnt);
-    
-    // 수정 모드 플래그 초기화
-    currentEditingIndex = -1;
-  } else {
-    // 신규 추가 모드: 배열에 추가하고 리스트에 추가
-    var add_server_html = "";
+  addServerConfigToList(express_form);
 
-    Express_Server_Config_Arr.push(express_form);
-
-    var displayServerCnt = '(' + server_cnt + ')';
-    add_server_html += '<li class="removebullet btn btn-info" onclick="webconsolejs[\'partials/operation/manage/mcicreate\'].view_express(\'' + express_data_cnt + '\')">'
-      + server_name + displayServerCnt
-      + '</li>';
-
-    var vmEleId = "vm";
-    if (!isVm) {
-      vmEleId = "mci";
-    }
-    $("#" + vmEleId + "_plusVmIcon").remove();
-    $("#" + vmEleId + "_server_list").append(add_server_html);
-    $("#" + vmEleId + "_server_list").prepend(getPlusVm(vmEleId));
-
-    express_data_cnt++;
-  }
-  
   // 서버 입력 폼 숨기기
   var div = document.getElementById("server_configuration");
   webconsolejs["partials/layout/navigatePages"].toggleSubElement(div);
@@ -531,6 +492,50 @@ export function expressDone_btn() {
   
   // 모달들 초기화
   resetModals();
+}
+
+// express_form을 Express_Server_Config_Arr에 반영(신규 push 또는 수정 모드 갱신) + <li> 렌더
+function addServerConfigToList(express_form) {
+  var server_name = express_form.name;
+  var server_cnt = parseInt(express_form.subGroupSize);
+
+  // 수정 모드인지 신규 추가 모드인지 판단
+  if (currentEditingIndex >= 0 && currentEditingIndex < Express_Server_Config_Arr.length) {
+    // 수정 모드: 기존 데이터를 업데이트
+    Express_Server_Config_Arr[currentEditingIndex] = express_form;
+
+    // 리스트 아이템 텍스트 업데이트
+    var vmEleId = "vm";
+    if (!isVm) {
+      vmEleId = "mci";
+    }
+    var displayServerCnt = '(' + server_cnt + ')';
+    var listItem = $("#" + vmEleId + "_server_list li").eq(currentEditingIndex + 1); // +1은 plusIcon 때문
+    listItem.text(server_name + displayServerCnt);
+
+    // 수정 모드 플래그 초기화
+    currentEditingIndex = -1;
+  } else {
+    // 신규 추가 모드: 배열에 추가하고 리스트에 추가
+    var add_server_html = "";
+
+    Express_Server_Config_Arr.push(express_form);
+
+    var displayServerCnt = '(' + server_cnt + ')';
+    add_server_html += '<li class="removebullet btn btn-info" onclick="webconsolejs[\'partials/operation/manage/mcicreate\'].view_express(\'' + express_data_cnt + '\')">'
+      + server_name + displayServerCnt
+      + '</li>';
+
+    var vmEleId = "vm";
+    if (!isVm) {
+      vmEleId = "mci";
+    }
+    $("#" + vmEleId + "_plusVmIcon").remove();
+    $("#" + vmEleId + "_server_list").append(add_server_html);
+    $("#" + vmEleId + "_server_list").prepend(getPlusVm(vmEleId));
+
+    express_data_cnt++;
+  }
 }
 
 // 모달들 초기화 함수
@@ -1306,4 +1311,64 @@ export async function deployFromSelectedTemplate() {
 		if (deployBtn) deployBtn.disabled = false;
 		webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR, "Failed to deploy from template: " + (e?.message || e));
 	}
+}
+
+// 선택한 template의 nodeGroups를 기존 SubGroup 목록에 추가(append) — 수정 후 배포용 프리필
+// infra 단위 값(description/policyOnPartialFailure/installMonAgent/sgTemplateId/vNetTemplateId/postCommand.userName·timeoutMinutes)은
+// 이 모듈 상태에 보관만 하고, 실제 배포 payload 병합은 WEB-TECH-019(FR-05-02)에서 처리한다.
+let templatePrefillInfraState = null;
+
+export function addTemplateToForm() {
+	const selected = templateSelectTable ? templateSelectTable.getSelectedData() : [];
+	if (selected.length === 0) {
+		webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR, "Please select a template");
+		return;
+	}
+	const template = selected[0];
+	const req = template.infraDynamicReq || {};
+	const groups = req.nodeGroups || [];
+
+	// 항상 append 모드로 동작 — 모달 오픈 시점에 편집 중이던 상태가 남아있지 않도록 방어
+	currentEditingIndex = -1;
+
+	groups.forEach(function (g, idx) {
+		var express_form = {};
+		express_form["provider"] = (g.specId || "").split("+")[0];
+		express_form["connectionName"] = g.connectionName || "";
+		express_form["name"] = g.name || "";
+		express_form["description"] = g.description || "";
+		express_form["subGroupSize"] = String(g.nodeGroupSize != null ? g.nodeGroupSize : 1);
+		express_form["rootDiskSize"] = g.rootDiskSize;
+		express_form["rootDiskType"] = g.rootDiskType || "";
+		express_form["commonSpec"] = g.specId || "";
+		express_form["commonImage"] = g.imageId || "";
+		express_form["imageId"] = g.imageId || "";
+		express_form["specId"] = g.specId || "";
+		// infra 단위 postCommand는 첫 SubGroup에만 반영(기존 command 처리 관례와 동일)
+		express_form["command"] = idx === 0 ? (req.postCommand?.command || []).join("\n") : "";
+
+		// 정식 매핑 승격 5필드(CreateNodeGroupDynamicReq) — template에 값이 있을 때만 carry-through
+		if (g.zone) express_form["zone"] = g.zone;
+		if (g.nodeUserPassword) express_form["nodeUserPassword"] = g.nodeUserPassword;
+		if (g.label && Object.keys(g.label).length > 0) express_form["label"] = g.label;
+		if (g.vNetTemplateId) express_form["vNetTemplateId"] = g.vNetTemplateId;
+		if (g.sgTemplateId) express_form["sgTemplateId"] = g.sgTemplateId;
+
+		addServerConfigToList(express_form);
+	});
+
+	templatePrefillInfraState = {
+		description: req.description || "",
+		policyOnPartialFailure: req.policyOnPartialFailure || "",
+		installMonAgent: req.installMonAgent || "",
+		vNetTemplateId: req.vNetTemplateId || "",
+		sgTemplateId: req.sgTemplateId || "",
+		postCommandUserName: req.postCommand?.userName || "",
+		postCommandTimeoutMinutes: req.postCommand?.timeoutMinutes
+	};
+	if (!$("#mci_desc").val() && templatePrefillInfraState.description) {
+		$("#mci_desc").val(templatePrefillInfraState.description);
+	}
+
+	bootstrap.Modal.getInstance(document.getElementById("infra-template-select-modal"))?.hide();
 }

--- a/front/templates/pages/operations/manage/workloads/mciworkloads.html
+++ b/front/templates/pages/operations/manage/workloads/mciworkloads.html
@@ -804,6 +804,7 @@
                   <option value="express">Express</option>
                   <option value="simple">Simple</option>
                   <option value="expert">Expert</option>
+                  <option value="template">Template</option>
                 </select>
               </div>
 

--- a/front/templates/pages/operations/manage/workloads/mciworkloads.html
+++ b/front/templates/pages/operations/manage/workloads/mciworkloads.html
@@ -1746,6 +1746,14 @@
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
         <button
           type="button"
+          id="btn-add-nodegroup-to-form"
+          class="btn btn-outline-primary"
+          onclick="webconsolejs['partials/operation/manage/mcicreate'].addTemplateToForm()"
+        >
+          Add NodeGroup
+        </button>
+        <button
+          type="button"
           id="btn-deploy-from-template"
           class="btn btn-primary"
           onclick="webconsolejs['partials/operation/manage/mcicreate'].deployFromSelectedTemplate()"

--- a/front/templates/pages/settings/accountnaccess/organizations/companyinfo.html
+++ b/front/templates/pages/settings/accountnaccess/organizations/companyinfo.html
@@ -6,22 +6,33 @@
         <!-- Info Card -->
         <div class="card" id="companyinfo-view-card">
           <div class="card-header">
-            <h3 class="card-title">Organization Info</h3>
+            <h3 class="card-title">Company Info</h3>
             <div class="card-actions btn-actions">
-              <button class="btn btn-outline-warning" id="companyinfo-edit-btn" onclick="companyInfoPage.enterEditMode()">
-                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+              <button class="btn btn-outline-secondary d-none" id="companyinfo-activate-btn"
+                onclick="companyInfoPage.activate()">Activate</button>
+              <button class="btn btn-outline-warning d-none" id="companyinfo-edit-btn"
+                onclick="companyInfoPage.enterEditMode()">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"
+                  viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"
+                  stroke-linecap="round" stroke-linejoin="round">
                   <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
                   <path d="M7 7h-1a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-1"></path>
-                  <path d="M20.385 6.585a2.1 2.1 0 0 0 -2.97 -2.97l-8.415 8.385v3h3l8.385 -8.415z"></path>
+                  <path d="M20.385 6.585a2.1 2.1 0 0 0 -2.97 -2.97l-8.415 8.385v3h3l8.385 -8.415z">
+                  </path>
                   <path d="M16 5l3 3"></path>
                 </svg>
                 Edit
               </button>
+              <button class="btn btn-primary d-none" id="companyinfo-create-btn"
+                onclick="companyInfoPage.enterCreateMode()">Create Company</button>
             </div>
           </div>
           <div class="card-body">
             <div id="companyinfo-loading" class="text-center py-4">
               <div class="spinner-border text-primary" role="status"></div>
+            </div>
+            <div id="companyinfo-empty" class="text-secondary py-3" style="display:none;">
+              No company is registered. Create the platform company to continue.
             </div>
             <div id="companyinfo-data" style="display:none;">
               <div class="datagrid">
@@ -30,24 +41,32 @@
                   <div class="datagrid-content" id="ci-name"></div>
                 </div>
                 <div class="datagrid-item">
-                  <div class="datagrid-title">Code</div>
-                  <div class="datagrid-content"><code id="ci-code"></code></div>
-                </div>
-                <div class="datagrid-item">
-                  <div class="datagrid-title">Level</div>
-                  <div class="datagrid-content" id="ci-level"></div>
-                </div>
-                <div class="datagrid-item">
-                  <div class="datagrid-title">Path</div>
-                  <div class="datagrid-content" id="ci-path"></div>
-                </div>
-                <div class="datagrid-item">
                   <div class="datagrid-title">Description</div>
                   <div class="datagrid-content" id="ci-description"></div>
                 </div>
                 <div class="datagrid-item">
-                  <div class="datagrid-title">Members</div>
-                  <div class="datagrid-content" id="ci-user-count"></div>
+                  <div class="datagrid-title">Status</div>
+                  <div class="datagrid-content" id="ci-status"></div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Created At</div>
+                  <div class="datagrid-content" id="ci-created-at"></div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Updated At</div>
+                  <div class="datagrid-content" id="ci-updated-at"></div>
+                </div>
+              </div>
+
+              <h4 class="mt-4 mb-2">Keycloak Settings</h4>
+              <div class="datagrid">
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Realm Name</div>
+                  <div class="datagrid-content"><code id="ci-realm"></code></div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Keycloak Client ID</div>
+                  <div class="datagrid-content"><code id="ci-client-id"></code></div>
                 </div>
               </div>
             </div>
@@ -57,21 +76,75 @@
         <!-- Edit Card -->
         <div class="card" id="companyinfo-edit-card" style="display:none;">
           <div class="card-header">
-            <h3 class="card-title">Edit Organization Info</h3>
+            <h3 class="card-title">Edit Company Info</h3>
           </div>
           <div class="card-body">
             <div class="mb-3">
               <label class="form-label required">Name</label>
-              <input type="text" class="form-control" id="ci-edit-name" placeholder="Organization name" />
+              <input type="text" class="form-control" id="ci-edit-name" placeholder="Company name" />
             </div>
             <div class="mb-3">
               <label class="form-label">Description</label>
-              <textarea class="form-control" id="ci-edit-description" rows="3" placeholder="Organization description"></textarea>
+              <textarea class="form-control" id="ci-edit-description" rows="3"
+                placeholder="Company description"></textarea>
+            </div>
+
+            <h4 class="mt-4 mb-2">Keycloak Settings</h4>
+            <div class="mb-3">
+              <label class="form-label">Realm Name</label>
+              <input type="text" class="form-control" id="ci-edit-realm" readonly disabled />
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Keycloak Client ID</label>
+              <input type="text" class="form-control" id="ci-edit-client-id" readonly disabled />
             </div>
           </div>
           <div class="card-footer text-end">
-            <button type="button" class="btn btn-secondary me-2" onclick="companyInfoPage.cancelEdit()">Cancel</button>
-            <button type="button" class="btn btn-primary" onclick="companyInfoPage.saveEdit()">Save</button>
+            <button type="button" class="btn btn-secondary me-2"
+              onclick="companyInfoPage.cancelEdit()">Cancel</button>
+            <button type="button" class="btn btn-primary"
+              onclick="companyInfoPage.saveEdit()">Save</button>
+          </div>
+        </div>
+
+        <!-- Create Card -->
+        <div class="card" id="companyinfo-create-card" style="display:none;">
+          <div class="card-header">
+            <h3 class="card-title">Create Company</h3>
+          </div>
+          <div class="card-body">
+            <div class="mb-3">
+              <label class="form-label required">Name</label>
+              <input type="text" class="form-control" id="ci-create-name" placeholder="Company name" />
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Description</label>
+              <textarea class="form-control" id="ci-create-description" rows="3"
+                placeholder="Company description"></textarea>
+            </div>
+
+            <h4 class="mt-4 mb-2">Keycloak Settings</h4>
+            <div class="mb-3">
+              <label class="form-label required">Realm Name</label>
+              <input type="text" class="form-control" id="ci-create-realm"
+                placeholder="Keycloak realm name" />
+            </div>
+            <div class="mb-3">
+              <label class="form-label required">Keycloak Client ID</label>
+              <input type="text" class="form-control" id="ci-create-client-id"
+                placeholder="Keycloak client id" />
+            </div>
+            <div class="mb-3">
+              <label class="form-label required">Keycloak Client Secret</label>
+              <input type="password" class="form-control" id="ci-create-client-secret"
+                placeholder="Keycloak client secret" autocomplete="new-password" />
+            </div>
+          </div>
+          <div class="card-footer text-end">
+            <button type="button" class="btn btn-secondary me-2"
+              onclick="companyInfoPage.cancelCreate()">Cancel</button>
+            <button type="button" class="btn btn-primary"
+              onclick="companyInfoPage.saveCreate()">Create</button>
           </div>
         </div>
 
@@ -82,5 +155,5 @@
 
 {{ partial("partials/layout/pageloader.html") | raw }}
 
-{{ javascriptTag("common/api/services/groups_api.js") | raw }}
+{{ javascriptTag("common/api/services/company_api.js") | raw }}
 {{ javascriptTag("pages/settings/accountnaccess/organizations/companyinfo.js") | raw }}

--- a/front/templates/partials/operation/manage/_mcicreate.html
+++ b/front/templates/partials/operation/manage/_mcicreate.html
@@ -206,6 +206,11 @@
               </div>
             </div>
           </div>
+          <!-- template Add NodeGroup carry-through 필드 read-only 표시 — 값이 있을 때만 JS가 렌더 -->
+          <div class="form-group mb-2 d-none" id="carry_through_section">
+            <label class="form-label">Template-defined Fields (read-only)</label>
+            <div class="row g-2" id="carry_through_fields"></div>
+          </div>
         </div>
         <div class="card-footer">
           <div align="right">

--- a/front/templates/partials/operation/manage/_mcicreate.html
+++ b/front/templates/partials/operation/manage/_mcicreate.html
@@ -206,9 +206,9 @@
               </div>
             </div>
           </div>
-          <!-- template Add NodeGroup carry-through 필드 read-only 표시 — 값이 있을 때만 JS가 렌더 -->
+          <!-- template Add NodeGroup carry-through 필드 read-only 표시 — 5필드 항상 렌더, 잠김은 스타일로 구분 -->
           <div class="form-group mb-2 d-none" id="carry_through_section">
-            <label class="form-label">Template-defined Fields (read-only)</label>
+            <label class="form-label">Template-defined Fields</label>
             <div class="row g-2" id="carry_through_fields"></div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- feat: Infra Template Add NodeGroup — 생성 폼 프리필(추가) 매핑 (#222)
- feat: MCI 배포 nodeGroups 매핑에 정식 필드 5개 추가 및 매핑 버그 수정 (#225)
- feat: 편집 폼 template carry-through 필드 read-only 표시 및 Extend VM template Add NodeGroup 지원 (#229)
- feat: template carry-through 필드 항상 표시 및 잠김 스타일 구분 (#230)
- feat: Company Info 화면을 Company API로 전환 (#227)
- fix: remote command localhost 하드코딩 제거 — getapihosts 기반 주소 해석 (#228)
- fix: navbar 알림 폴링 정지 조건 추가 및 완료 토스트 반복 표시 제거 (#226)
- fix: navbar 워크스페이스/프로젝트 셀렉터를 본인 소속 범위로 스코프 (#223)
- fix: project 단건조회/수정/삭제 operationId legacy 경로 수정 (#224)

## Dependencies
- Requires **mc-iam-manager v0.6.1** (m-cmp/mc-iam-manager#89) 